### PR TITLE
Use dataframe.groupby instead of iterating (rebased)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
     - source activate pyenv
     - python -m pip install -U pip
     - pip install pytest
+    - pip install pytest-benchmark
     - pip install .
     - pip install ortools
 

--- a/motmetrics/metrics.py
+++ b/motmetrics/metrics.py
@@ -479,6 +479,7 @@ def id_global_assignment(df, ana = None):
     #st1 = time.time()
     oids = df.full['OId'].dropna().unique()
     hids = df.full['HId'].dropna().unique()
+    oids_idx = dict((o,i) for i,o in enumerate(oids))
     hids_idx = dict((h,i) for i,h in enumerate(hids))
     #print('----'*2, '1', time.time()-st1)
     flat = df.raw.reset_index()
@@ -514,7 +515,8 @@ def id_global_assignment(df, ana = None):
         fpmatrix[c+no,c] = hc
 
     #print('----'*2, '5', time.time()-st1)
-    for (r, c), ex in tpcs.items():
+    for (oid, hid), ex in tpcs.items():
+        r, c = oids_idx[oid], hids_idx[hid]
         fpmatrix[r,c] -= ex
         fnmatrix[r,c] -= ex
 

--- a/motmetrics/metrics.py
+++ b/motmetrics/metrics.py
@@ -162,12 +162,7 @@ class MetricsHost:
         elif isinstance(metrics, str):
             metrics = [metrics]
 
-        class DfMap : pass
-        df_map = DfMap()
-        df_map.full = df     
-        df_map.raw = df[df.Type == 'RAW']
-        df_map.noraw = df[(df.Type != 'RAW') & (df.Type != 'ASCEND') & (df.Type != 'TRANSFER') & (df.Type != 'MIGRATE')]
-        df_map.extra = df[df.Type != 'RAW']
+        df_map = events_to_df_map(df)
 
         cache = {}
         options = {'ana': ana}
@@ -474,59 +469,72 @@ def recall(df, num_detections, num_objects):
 def recall_m(partials, num_detections, num_objects):
     return _qdiv(num_detections, num_objects)
 
-def id_global_assignment(df, ana = None):
-    """ID measures: Global min-cost assignment for ID measures."""
-    #st1 = time.time()
+def events_to_df_map(df):
+    class DfMap : pass
+    df_map = DfMap()
+    df_map.full = df
+    df_map.raw = df[df.Type == 'RAW']
+    df_map.noraw = df[(df.Type != 'RAW') & (df.Type != 'ASCEND') & (df.Type != 'TRANSFER') & (df.Type != 'MIGRATE')]
+    df_map.extra = df[df.Type != 'RAW']
+    return df_map
+
+def extract_counts_from_df_map(df):
+    """
+    Returns:
+        Tuple (ocs, hcs, tps).
+        ocs: Dict from object id to count.
+        hcs: Dict from hypothesis id to count.
+        tps: Dict from (object id, hypothesis id) to true-positive count.
+        The ids are arbitrary, they might NOT be consecutive integers from 0.
+    """
     oids = df.full['OId'].dropna().unique()
     hids = df.full['HId'].dropna().unique()
-    oids_idx = dict((o,i) for i,o in enumerate(oids))
-    hids_idx = dict((h,i) for i,h in enumerate(hids))
-    #print('----'*2, '1', time.time()-st1)
+
     flat = df.raw.reset_index()
-    if ana is None:
-        # Count number of frames where each (non-empty) OId and HId appears.
-        hcs = list(flat.set_index('HId')['FrameId'].groupby('HId').nunique()[hids])
-        ocs = list(flat.set_index('OId')['FrameId'].groupby('OId').nunique()[oids])
-    else:
-        hcs = [ana['hyp'][int(h)] for h in hids if h!='nan' and np.isfinite(float(h))]
-        ocs = [ana['obj'][int(o)] for o in oids if o!='nan' and np.isfinite(float(o))]
-
-    #print('----'*2, '2', time.time()-st1)
-    no = oids.shape[0]
-    nh = hids.shape[0]   
-
+    # Exclude events that do not belong to either set.
+    flat = flat[flat['OId'].isin(oids) | flat['HId'].isin(hids)]
+    # Count number of frames where each (non-empty) OId and HId appears.
+    ocs = flat.set_index('OId')['FrameId'].groupby('OId').nunique().to_dict()
+    hcs = flat.set_index('HId')['FrameId'].groupby('HId').nunique().to_dict()
     # Count frames where object and hypothesis appear with non-empty distance.
     dists = flat.set_index(['OId', 'HId'])['D'].dropna()
-    tpcs = dict(dists.groupby(['OId', 'HId']).count())
+    tps = dists.groupby(['OId', 'HId']).count().to_dict()
+    return ocs, hcs, tps
 
-    #print('----'*2, '3', time.time()-st1)
+def id_global_assignment(df, ana = None):
+    """ID measures: Global min-cost assignment for ID measures."""
+    ocs, hcs, tps = extract_counts_from_df_map(df)
+    oids = sorted(ocs.keys())
+    hids = sorted(hcs.keys())
+    oids_idx = dict((o, i) for i, o in enumerate(oids))
+    hids_idx = dict((h, i) for i, h in enumerate(hids))
+    no = len(ocs)
+    nh = len(hcs)
+
     fpmatrix = np.full((no+nh, no+nh), 0.)
     fnmatrix = np.full((no+nh, no+nh), 0.)
     fpmatrix[no:, :nh] = np.nan
     fnmatrix[:no, nh:] = np.nan 
 
-    #print('----'*2, '4', time.time()-st1)
-    for r, oc in enumerate(ocs):
+    for oid, oc in ocs.items():
+        r = oids_idx[oid]
         fnmatrix[r, :nh] = oc
         fnmatrix[r,nh+r] = oc
 
-    for c, hc in enumerate(hcs):
+    for hid, hc in hcs.items():
+        c = hids_idx[hid]
         fpmatrix[:no, c] = hc
         fpmatrix[c+no,c] = hc
 
-    #print('----'*2, '5', time.time()-st1)
-    for (oid, hid), ex in tpcs.items():
-        r, c = oids_idx[oid], hids_idx[hid]
+    for (oid, hid), ex in tps.items():
+        r = oids_idx[oid]
+        c = hids_idx[hid]
         fpmatrix[r,c] -= ex
         fnmatrix[r,c] -= ex
 
-    #print('----'*2, '6', time.time()-st1)
-    #print(fpmatrix.shape, fnmatrix.shape)
     costs = fpmatrix + fnmatrix    
-    #print(costs.shape)
     rids, cids = linear_sum_assignment(costs)
 
-    #print('----'*2, '7', time.time()-st1)
     return {
         'fpmatrix' : fpmatrix,
         'fnmatrix' : fnmatrix,

--- a/motmetrics/tests/test_metrics.py
+++ b/motmetrics/tests/test_metrics.py
@@ -146,8 +146,6 @@ def accum_random_uniform(rand, seq_len, num_objs, num_hyps, objs_per_frame, hyps
         # Choose subset of hypotheses present in this frame.
         hyps = rand.choice(num_hyps, hyps_per_frame, replace=False)
         dist = rand.uniform(size=(objs_per_frame, hyps_per_frame))
-        # is_valid = (dist < sparsity)
-        # dist[~is_valid] = np.nan
         acc.update(objs, hyps, dist)
     return acc
 


### PR DESCRIPTION
I noticed that iteratively selecting rows from the dataframe was a serious bottleneck.

It looks like someone was already investigating this. I have removed the use of the cached analysis and the lines which computed timings.

I isolated the code for extracting counts and added a benchmark (and a dependency on `pytest-benchmark`).

Before:
```
--------------------------------------------------------- benchmark: 1 tests ---------------------------------------------------------
Name (time in s)                                  Min      Max     Mean  StdDev   Median     IQR  Outliers     OPS  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_extract_counts_from_df_map     15.4156  16.1166  15.6762  0.3507  15.4331  0.6114       1;0  0.0638       5           1
--------------------------------------------------------------------------------------------------------------------------------------
```

After (time in ms not s):
```
------------------------------------------------------------ benchmark: 1 tests ------------------------------------------------------------
Name (time in ms)                                  Min       Max      Mean   StdDev    Median      IQR  Outliers     OPS  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_extract_counts_from_df_map     146.5993  209.5080  175.8946  22.3510  174.9131  17.7610       2;0  5.6852       5           1
--------------------------------------------------------------------------------------------------------------------------------------------
```