### PR TITLE
ordering metrics & single compute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
+
 env:
   - PYTHON=3.5 PANDAS>=0.19.2
   - PYTHON=3.6 PANDAS>=0.19.2
+
 install:
     # Install conda
     - if [[ "$PYTHON" == "2.7" ]]; then
@@ -22,8 +24,7 @@ install:
     - conda create -q -n pyenv python=$PYTHON pandas=$PANDAS $deps
     - source activate pyenv
     - python -m pip install -U pip
-    - pip install pytest
-    - pip install pytest-benchmark
+    - pip install pytest pytest-benchmark
     - pip install .
     - pip install ortools
 

--- a/motmetrics/metrics.py
+++ b/motmetrics/metrics.py
@@ -166,9 +166,16 @@ class MetricsHost:
 
         df_map = events_to_df_map(df)
 
+        # sort the metrics according number of dependencies
+        metrics_deps = sorted([(m, len(self.metrics[m]['deps'])) for m in metrics], key=lambda e: e[1])
+        metrics = [m[0] for m in metrics_deps]
+
         cache = {}
         options = {'ana': ana}
         for mname in metrics:
+            if mname in cache:
+                # skip already computed metric based on dependencies
+                continue
             # st__ = time.time()
             # print(mname, ' start')
             cache[mname] = self._compute(df_map, mname, cache, options, parent='summarize')

--- a/motmetrics/tests/test_metrics.py
+++ b/motmetrics/tests/test_metrics.py
@@ -75,7 +75,8 @@ def test_metrics_with_no_events():
         acc,
         metrics=['motp', 'mota', 'num_predictions'],
         return_dataframe=False,
-        return_cached=True)
+        return_cached=True
+    )
     assert np.isnan(metr['mota'])
     assert np.isnan(metr['motp'])
     assert metr['num_predictions'] == 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.12.1
 pandas>=0.23.1
 scipy>=0.19.0
 xmltodict>=0.12.0
+pathos  # for multiprocessing


### PR DESCRIPTION
### Actual situaltion

the actual version takes any set of metrics and computes it almost in random order;
if it needs another metric (it is depending on it) it computes it on the fly...
this introduces several duplicities, which can be simply fixed and speed up the process 

### Solution

This change does:
1. order metrics according to min dependences
2. if a metric was already compted because of dependence, it is skipped later

### Process

it is a successor of #71 due to changed target branch... see https://github.com/cheind/py-motmetrics/pull/71#issuecomment-577618013