### PR TITLE
add `if metrics is None` check to compute_many

### DIFF
--- a/motmetrics/metrics.py
+++ b/motmetrics/metrics.py
@@ -267,6 +267,10 @@ class MetricsHost:
         df : pandas.DataFrame
             A datafrom containing the metrics in columns and names in rows.
         """
+        if metrics is None:
+            metrics = motchallenge_metrics
+        elif isinstance(metrics, str):
+            metrics = [metrics]
 
         assert names is None or len(names) == len(dfs)
         st = time.time()

--- a/motmetrics/metrics.py
+++ b/motmetrics/metrics.py
@@ -222,7 +222,7 @@ class MetricsHost:
             A datafrom containing the metrics in columns and names in rows.
         """
         if metrics is None:
-            metrics = self.names
+            metrics = motchallenge_metrics
         elif isinstance(metrics, str):
             metrics = [metrics]
         cache = {}


### PR DESCRIPTION
when calling `compute_many`, if kwarg `metrics` is left to its default value `None`, it will not calculate all metrics. This does not align with the Kwargs documentation on this function, nor the behavior of similar function `compute`.