### PR TITLE
Adding ignore zones for UA-DETRAC

### DIFF
--- a/motmetrics/apps/eval_detrac.py
+++ b/motmetrics/apps/eval_detrac.py
@@ -19,6 +19,8 @@ import os
 from pathlib import Path
 
 import motmetrics as mm
+# Andreu
+from motmetrics.utils import is_in_region
 
 
 def parse_args():
@@ -67,6 +69,17 @@ string.""", formatter_class=argparse.RawTextHelpFormatter)
     return parser.parse_args()
 
 
+# Andreu
+def filter_dets_by_zone(gt_df, test_df):
+    ig_region = gt_df[['X_reg', 'Y_reg', 'W_reg', 'H_reg']].dropna().values
+    dets = test_df[['X', 'Y', 'Width', 'Height']]
+    for idx, row in dets.iterrows():
+        bbox = [dets.at[idx, 'X'], dets.at[idx, 'Y'], dets.at[idx, 'Width'], dets.at[idx, 'Height']]
+        for reg in ig_region:
+            if is_in_region(bbox, reg):
+                test_df.drop([idx], axis=0, inplace=True)
+                break
+
 def compare_dataframes(gts, ts):
     """Builds accumulator for each sequence."""
     accs = []
@@ -74,6 +87,7 @@ def compare_dataframes(gts, ts):
     for k, tsacc in ts.items():
         if k in gts:
             logging.info('Comparing %s...', k)
+            filter_dets_by_zone(gts[k], tsacc)
             accs.append(mm.utils.compare_to_groundtruth(gts[k], tsacc, 'iou', distth=0.5))
             names.append(k)
         else:
@@ -104,6 +118,17 @@ def main():
 
     gt = OrderedDict([(os.path.splitext(Path(f).parts[-1])[0], mm.io.loadtxt(f, fmt=args.gtfmt)) for f in gtfiles])
     ts = OrderedDict([(os.path.splitext(Path(f).parts[-1])[0], mm.io.loadtxt(f, fmt=args.tsfmt)) for f in tsfiles])
+
+    # # Debug
+    # # f = gtfiles[1]
+    # # seq = os.path.splitext(Path(f).parts[-1])[0]
+    # seq = 'MVI_39511'
+    # f_gt = gtfiles[0].split('/')[:-1]
+    # f = '/'.join(f_gt) + '/' + seq + '.xml'
+    # gt = OrderedDict([(seq, mm.io.loadtxt(f, fmt=args.gtfmt))])
+    # f_test = tsfiles[0].split('/')[:-1]
+    # f = '/'.join(f_test) + '/' + seq + '.txt'
+    # ts = OrderedDict([(seq, mm.io.loadtxt(f, fmt=args.tsfmt))])
 
     mh = mm.metrics.create()
     accs, names = compare_dataframes(gt, ts)

--- a/motmetrics/apps/eval_detrac.py
+++ b/motmetrics/apps/eval_detrac.py
@@ -119,17 +119,6 @@ def main():
     gt = OrderedDict([(os.path.splitext(Path(f).parts[-1])[0], mm.io.loadtxt(f, fmt=args.gtfmt)) for f in gtfiles])
     ts = OrderedDict([(os.path.splitext(Path(f).parts[-1])[0], mm.io.loadtxt(f, fmt=args.tsfmt)) for f in tsfiles])
 
-    # # Debug
-    # # f = gtfiles[1]
-    # # seq = os.path.splitext(Path(f).parts[-1])[0]
-    # seq = 'MVI_39511'
-    # f_gt = gtfiles[0].split('/')[:-1]
-    # f = '/'.join(f_gt) + '/' + seq + '.xml'
-    # gt = OrderedDict([(seq, mm.io.loadtxt(f, fmt=args.gtfmt))])
-    # f_test = tsfiles[0].split('/')[:-1]
-    # f = '/'.join(f_test) + '/' + seq + '.txt'
-    # ts = OrderedDict([(seq, mm.io.loadtxt(f, fmt=args.tsfmt))])
-
     mh = mm.metrics.create()
     accs, names = compare_dataframes(gt, ts)
 

--- a/motmetrics/apps/eval_detrac.py
+++ b/motmetrics/apps/eval_detrac.py
@@ -19,7 +19,6 @@ import os
 from pathlib import Path
 
 import motmetrics as mm
-# Andreu
 from motmetrics.utils import is_in_region
 
 
@@ -69,7 +68,6 @@ string.""", formatter_class=argparse.RawTextHelpFormatter)
     return parser.parse_args()
 
 
-# Andreu
 def filter_dets_by_zone(gt_df, test_df):
     ig_region = gt_df[['X_reg', 'Y_reg', 'W_reg', 'H_reg']].dropna().values
     dets = test_df[['X', 'Y', 'Width', 'Height']]

--- a/motmetrics/io.py
+++ b/motmetrics/io.py
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 import scipy.io
 import xmltodict
-# Andreu
+
 from motmetrics.utils import is_in_region
 
 
@@ -277,7 +277,6 @@ def load_detrac_xml(fname):
     if type(ignored_region_list['box']) != list:
         ignored_region_list['box'] = [ignored_region_list['box']]
 
-    # Andreu
     parsed_ig = []
     for ig in ignored_region_list['box']:
         row = []

--- a/motmetrics/io.py
+++ b/motmetrics/io.py
@@ -18,6 +18,8 @@ import numpy as np
 import pandas as pd
 import scipy.io
 import xmltodict
+# Andreu
+from motmetrics.utils import is_in_region
 
 
 class Format(Enum):
@@ -271,6 +273,19 @@ def load_detrac_xml(fname):
     with io.open(fname) as fd:
         doc = xmltodict.parse(fd.read())
     frameList = doc['sequence']['frame']
+    ignored_region_list = doc['sequence']['ignored_region']
+    if type(ignored_region_list['box']) != list:
+        ignored_region_list['box'] = [ignored_region_list['box']]
+
+    # Andreu
+    parsed_ig = []
+    for ig in ignored_region_list['box']:
+        row = []
+        row.append(float(ig['@left']))
+        row.append(float(ig['@top']))
+        row.append(float(ig['@width']))
+        row.append(float(ig['@height']))
+        parsed_ig.append(row)
 
     parsedGT = []
     for f in frameList:
@@ -280,6 +295,7 @@ def load_detrac_xml(fname):
             targetList = [targetList]
 
         for t in targetList:
+            flag_ignore = False
             row = []
             row.append(fid)
             row.append(int(t['@id']))
@@ -291,10 +307,20 @@ def load_detrac_xml(fname):
             row.append(-1)
             row.append(-1)
             row.append(-1)
-            parsedGT.append(row)
+            bbox = [row[2], row[3], row[4], row[5]]
+            for reg in parsed_ig:
+                if is_in_region(bbox, reg):
+                    flag_ignore = True
+                    break
+            if not flag_ignore:
+                parsedGT.append(row)
 
     df = pd.DataFrame(parsedGT,
                       columns=['FrameId', 'Id', 'X', 'Y', 'Width', 'Height', 'Confidence', 'ClassId', 'Visibility', 'unused'])
+
+    df_reg = pd.DataFrame(parsed_ig, columns=['X_reg', 'Y_reg', 'W_reg', 'H_reg'])
+    df = df.append(df_reg)
+
     df.set_index(['FrameId', 'Id'], inplace=True)
 
     # Account for matlab convention.

--- a/motmetrics/utils.py
+++ b/motmetrics/utils.py
@@ -165,7 +165,6 @@ def CLEAR_MOT_M(gt, dt, inifile, dist='iou', distfields=None, distth=0.5, includ
     return acc, analysis
 
 
-# Andreu
 def is_in_region(bbox, reg):
     # Check if the 4 points of the bbox are inside region
     points = []


### PR DESCRIPTION
UA-DETRAC dataset does not have all the objects in the frames annotated. They use a so-called "ignore zones" to remove the detections that would correspond to False Positives for corresponding to a non-annotated object. This PR filters both ground truth and detections present in the ignore zones. 