### PR TITLE
Warn about changes in motmetrics.utils.compare_to_groundtruth() when using euclidean distance.

### DIFF
--- a/motmetrics/tests/test_utils.py
+++ b/motmetrics/tests/test_utils.py
@@ -31,7 +31,7 @@ def test_annotations_xor_predictions_present():
     }
     anno = _tracks_to_dataframe(anno_tracks)
     pred = _tracks_to_dataframe(pred_tracks)
-    acc = mm.utils.compare_to_groundtruth(anno, pred, 'euc', distfields=['Position'], distth=2)
+    acc = mm.utils.compare_to_groundtruth(anno, pred, 'euclidean', distfields=['Position'], distth=2)
     mh = mm.metrics.create()
     metrics = mh.compute(acc, return_dataframe=False, metrics=[
         'num_objects', 'num_predictions', 'num_unique_objects',

--- a/motmetrics/utils.py
+++ b/motmetrics/utils.py
@@ -38,7 +38,7 @@ def compare_to_groundtruth(gt, dt, dist='iou', distfields=None, distth=0.5):
     ------
     dist : str, optional
         String identifying distance to be used. Defaults to intersection over union ('iou'). Euclidean
-        distance ('euc') and squared euclidean distance ('seuc') are also supported.
+        distance ('euclidean') and squared euclidean distance ('seuc') are also supported.
     distfields: array, optional
         Fields relevant for extracting distance information. Defaults to ['X', 'Y', 'Width', 'Height']
     distth: float, optional
@@ -61,10 +61,14 @@ def compare_to_groundtruth(gt, dt, dist='iou', distfields=None, distth=0.5):
         compute_dist = compute_iou
     elif dist.upper() == 'EUC':
         compute_dist = compute_euc
+        import warnings
+        warnings.warn(f"'euc' flag changed its behavior. The euclidean distance is now used instead of the squared euclidean distance. Make sure the used threshold (distth={distth}) is not squared. Use 'euclidean' flag to avoid this warning.")
+    elif dist.upper() == 'EUCLIDEAN':
+        compute_dist = compute_euc
     elif dist.upper() == 'SEUC':
         compute_dist = compute_seuc
     else:
-        raise f'Unknown distance metric {dist}. Use "IOU", "EUC" or "SEUC"'
+        raise f'Unknown distance metric {dist}. Use "IOU", "EUCLIDEAN",  or "SEUC"'
 
     acc = MOTAccumulator()
 


### PR DESCRIPTION
Warn about the changes performed in pull request: https://github.com/cheind/py-motmetrics/pull/168
If someone uses the method with dist='euc', the threshold should be set to the euclidean distance and not to the squared euclidean distance, as in previous versions.
A new option was added that does not show this warning: dist='euclidean'.
