### PR TITLE
Keep the MultiIndex of the df even if empty

### DIFF
--- a/motmetrics/mot.py
+++ b/motmetrics/mot.py
@@ -454,7 +454,8 @@ class MOTAccumulator(object):
                 next_frame_id = max(r.index.get_level_values(0).max() + 1, r.index.get_level_values(0).unique().shape[0])
                 if np.isnan(next_frame_id):
                     next_frame_id = 0
-                copy.index = copy.index.map(lambda x: (x[0] + next_frame_id, x[1]))
+                if not copy.index.empty:
+                    copy.index = copy.index.map(lambda x: (x[0] + next_frame_id, x[1]))
                 infos['frame_offset'] = next_frame_id
 
             # Update object / hypothesis ids


### PR DESCRIPTION
I just faced this: 

- In the given line, `copy.index` was an empty `pd.MultiIndex` with specified columns `['FrameId', 'Event']`, as it was supposed to be. 
- Then, however, the line turned it into an empty `Index` (not `MultiIndex`) without any specified columns. 
- This messed up `r` further on: its index also became just `Index`, though, with a tuple in each entry. This screwed up `r.index.get_level_values(0).max() + 1` because you cannot add `1` to a tuple.

The proposed change should prevent this from happening while maintaining the intended behavior.

I am using pandas==2.1.2 and Python 3.10