### PR TITLE
Set options = {} to prevent errors

### DIFF
--- a/motmetrics/metrics.py
+++ b/motmetrics/metrics.py
@@ -200,7 +200,10 @@ class MetricsHost:
         df_map = events_to_df_map(df)
 
         cache = {}
-        options = {"ana": ana}
+        if ana is None:
+            options = {}
+        else:
+            options = {"ana": ana}
         for mname in metrics:
             cache[mname] = self._compute(
                 df_map, mname, cache, options, parent="summarize"


### PR DESCRIPTION
This PR resolve #190  issue.

When we utilize motmetrics with other packages such as nuscenes-devkit, options = {"ana": ana} sometimes cause errors.
This PR set options = {} when ana is None and prevent errors.
