### PR TITLE
ci: remove broken lapsolver dependency

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,11 @@ jobs:
                   pip install --upgrade pip==22.0.3
                   python -m pip install flake8 pytest pytest-benchmark        
                   if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-                  pip install lap scipy "ortools<9.4" lapsolver munkres
+                  # lapsolver is unmaintained and no longer builds with the C++
+                  # toolchain on current GitHub-hosted runners. The test suite
+                  # discovers optional solvers dynamically, so exercise the
+                  # maintained LAP backends here instead.
+                  pip install lap scipy "ortools<9.4" munkres
             - name: Lint with flake8
               run: |
                   # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
## Summary

- remove the unmaintained `lapsolver` package from the GitHub Actions dependency installation
- retain CI coverage for the maintained `lap`, SciPy, OR-Tools, and Munkres backends

## Root cause

`lapsolver` is built from source and its bundled C++/pybind11 code no longer compiles with the toolchain on current GitHub-hosted runners. Dependency installation therefore fails before linting or tests begin.

The solver tests discover installed optional backends dynamically, so removing this broken optional package does not require changing runtime behavior.

## Testing

- `git diff --check` ✅
- `python -m pytest -q` — 48 tests passed; one local setup error because `pytest-benchmark` is absent from the parent environment. CI explicitly installs `pytest-benchmark`.
