### PR TITLE
Add one-call MOTChallenge evaluation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ uv pip install --group dev
 
 ## Quick Start
 
-For MOTChallenge-style text files, compute and print metrics in one call:
+For MOTChallenge-style text files, compute and print metrics in one call. Supported file formats are detected automatically.
 
 ```python
 import motmetrics as mm
@@ -99,6 +99,7 @@ Useful lower-level pieces:
 
 - `mm.MOTAccumulator` stores frame-level matching events.
 - `mm.distances` contains distance helpers such as IoU and Euclidean matrices.
+- `mm.io.loadtxt(..., fmt="auto")` detects MOTChallenge text, VATIC text, and UA-DETRAC MAT/XML files.
 - `mm.metrics.create()` returns a `MetricsHost` for custom metric selection.
 - `mm.utils.compare_to_groundtruth` compares loaded dataframes directly.
 - `mm.utils.compare_to_groundtruth_reweighting` supports custom HOTA-style multi-threshold workflows.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 pip install motmetrics
 ```
 
-Python 3.8 through 3.14 is supported. NumPy, pandas, SciPy, and xmltodict are installed as dependencies.
+Python 3.8 through 3.14 is supported.
 
 For development:
 

--- a/README.md
+++ b/README.md
@@ -79,27 +79,6 @@ The default MOTChallenge summary includes the commonly reported CLEAR, Identity,
 
 ## Advanced Use
 
-Use the accumulator API when your data is not in MOTChallenge format, distances are already available, or you need custom matching behavior:
-
-```python
-import motmetrics as mm
-import numpy as np
-
-acc = mm.MOTAccumulator(auto_id=True)
-acc.update(
-    [1, 2],
-    [1, 2, 3],
-    np.array([
-        [0.1, np.nan, 0.3],
-        [0.5, 0.2, 0.3],
-    ]),
-)
-
-mh = mm.metrics.create()
-summary = mh.compute(acc, metrics=["num_frames", "mota", "motp"], name="acc")
-print(summary)
-```
-
 Useful lower-level pieces:
 
 - `mm.MOTAccumulator` stores frame-level matching events.

--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ List all registered metrics:
 ```python
 import motmetrics as mm
 
-mh = mm.metrics.create()
-print(mh.list_metrics_markdown())
+print(mm.list_metrics_markdown())
 ```
 
 The default MOTChallenge summary includes the commonly reported CLEAR, Identity, and HOTA metrics.

--- a/README.md
+++ b/README.md
@@ -2,661 +2,137 @@
 
 # py-motmetrics
 
-The **py-motmetrics** library provides a Python implementation of metrics for benchmarking multiple object trackers (MOT).
+**py-motmetrics** provides Python tools for evaluating multiple object tracking (MOT) results. It implements MOTChallenge-aligned CLEAR MOT, Identity, and HOTA-related metrics, including MOTA, MOTP, IDF1, precision, recall, and track quality counts.
 
-While benchmarking single object trackers is rather straightforward, measuring the performance of multiple object trackers needs careful design as multiple correspondence constellations can arise (see image below). A variety of methods have been proposed in the past and while there is no general agreement on a single method, the methods of [[1,2,3,4]](#References) have received considerable attention in recent years. **py-motmetrics** implements these [metrics](#Metrics).
+## Installation
 
-<div style="text-align:center;">
+```bash
+pip install motmetrics
+```
 
-![](./motmetrics/etc/mot.png)<br/>
+Python 3.8 through 3.14 is supported. NumPy, pandas, SciPy, and xmltodict are installed as dependencies.
 
-_Pictures courtesy of Bernardin, Keni, and Rainer Stiefelhagen [[1]](#References)_
+For development:
 
-</div>
+```bash
+uv venv
+uv pip install --group dev
+```
 
-In particular **py-motmetrics** supports `CLEAR-MOT`[[1,2]](#References) metrics and `ID`[[4]](#References) metrics. Both metrics attempt to find a minimum cost assignment between ground truth objects and predictions. However, while CLEAR-MOT solves the assignment problem on a local per-frame basis, `ID-MEASURE` solves the bipartite graph matching by finding the minimum cost of objects and predictions over all frames. This [blog-post](https://web.archive.org/web/20190413133409/http://vision.cs.duke.edu:80/DukeMTMC/IDmeasures.html) by Ergys illustrates the differences in more detail.
+## Quick Start
 
-## Features at a glance
-
--   _Variety of metrics_ <br/>
-    Provides MOTA, MOTP, track quality measures, global ID measures and more. The results are [comparable](#MOTChallengeCompatibility) with the popular [MOTChallenge][motchallenge] benchmarks [(\*1)](#asterixcompare).
--   _Distance agnostic_ <br/>
-    Supports Euclidean, Intersection over Union and other distances measures.
--   _Complete event history_ <br/>
-    Tracks all relevant per-frame events suchs as correspondences, misses, false alarms and switches.
--   _Flexible solver backend_ <br/>
-    Support for switching minimum assignment cost solvers. Supports `scipy`, `ortools`, `munkres` out of the box. Auto-tunes solver selection based on [availability and problem size](#SolverBackends).
--   _Easy to extend_ <br/>
-    Events and summaries are utilizing [pandas][pandas] for data structures and analysis. New metrics can reuse already computed values from depending metrics.
-
-<a name="Metrics"></a>
-
-## Metrics
-
-**py-motmetrics** implements the following metrics. The metrics have been aligned with what is reported by [MOTChallenge][motchallenge] benchmarks.
+For MOTChallenge-style text files, compute and print metrics in one call:
 
 ```python
 import motmetrics as mm
-# List all default metrics
+
+summary = mm.evaluate_motchallenge("path/to/gt.txt", "path/to/pred.txt")
+print(summary)
+```
+
+`summary` displays as a MOTChallenge-style table and keeps the raw pandas data available:
+
+```python
+summary.mota
+summary.idf1
+summary.df.to_csv("metrics.csv")
+```
+
+Folder evaluation uses the same function:
+
+```python
+summary = mm.evaluate_motchallenge("path/to/gt_root", "path/to/preds_root")
+print(summary)
+```
+
+Expected folder layout:
+
+```text
+gt_root/<SEQUENCE>/gt/gt.txt
+preds_root/<SEQUENCE>.txt
+```
+
+The command-line evaluator is still available:
+
+```bash
+python -m motmetrics.apps.eval_motchallenge path/to/gt_root path/to/preds_root
+```
+
+## Metrics
+
+List all registered metrics:
+
+```python
+import motmetrics as mm
+
 mh = mm.metrics.create()
 print(mh.list_metrics_markdown())
 ```
 
-| Name                 | Description                                                                        |
-| :------------------- | :--------------------------------------------------------------------------------- |
-| num_frames           | Total number of frames.                                                            |
-| num_matches          | Total number matches.                                                              |
-| num_switches         | Total number of track switches.                                                    |
-| num_false_positives  | Total number of false positives (false-alarms).                                    |
-| num_misses           | Total number of misses.                                                            |
-| num_detections       | Total number of detected objects including matches and switches.                   |
-| num_objects          | Total number of unique object appearances over all frames.                         |
-| num_predictions      | Total number of unique prediction appearances over all frames.                     |
-| num_unique_objects   | Total number of unique object ids encountered.                                     |
-| mostly_tracked       | Number of objects tracked for at least 80 percent of lifespan.                     |
-| partially_tracked    | Number of objects tracked between 20 and 80 percent of lifespan.                   |
-| mostly_lost          | Number of objects tracked less than 20 percent of lifespan.                        |
-| num_fragmentations   | Total number of switches from tracked to not tracked.                              |
-| motp                 | Multiple object tracker precision.                                                 |
-| mota                 | Multiple object tracker accuracy.                                                  |
-| precision            | Number of detected objects over sum of detected and false positives.               |
-| recall               | Number of detections over number of objects.                                       |
-| idfp                 | ID measures: Number of false positive matches after global min-cost matching.      |
-| idfn                 | ID measures: Number of false negatives matches after global min-cost matching.     |
-| idtp                 | ID measures: Number of true positives matches after global min-cost matching.      |
-| idp                  | ID measures: global min-cost precision.                                            |
-| idr                  | ID measures: global min-cost recall.                                               |
-| idf1                 | ID measures: global min-cost F1 score.                                             |
-| obj_frequencies      | `pd.Series` Total number of occurrences of individual objects over all frames.     |
-| pred_frequencies     | `pd.Series` Total number of occurrences of individual predictions over all frames. |
-| track_ratios         | `pd.Series` Ratio of assigned to total appearance count per unique object id.      |
-| id_global_assignment | `dict` ID measures: Global min-cost assignment for ID measures.                    |
-| deta_alpha           | HOTA: Detection Accuracy (DetA) for a given threshold.                             |
-| assa_alpha           | HOTA: Association Accuracy (AssA) for a given threshold.                           |
-| hota_alpha           | HOTA: Higher Order Tracking Accuracy (HOTA) for a given threshold.                 |
+The default MOTChallenge summary includes the commonly reported CLEAR and Identity metrics. HOTA-related metrics are available through the lower-level API because they require matching over multiple alpha thresholds.
 
-<a name="MOTChallengeCompatibility"></a>
+## Advanced Use
 
-## MOTChallenge compatibility
+Use the accumulator API when your data is not in MOTChallenge format, distances are already available, or you need custom matching behavior:
 
-**py-motmetrics** produces results compatible with popular [MOTChallenge][motchallenge] benchmarks [(\*1)](#asterixcompare). Below are two results taken from MOTChallenge [Matlab devkit][devkit] corresponding to the results of the CEM tracker on the training set of the 2015 MOT 2DMark.
+```python
+import motmetrics as mm
+import numpy as np
 
+acc = mm.MOTAccumulator(auto_id=True)
+acc.update(
+    [1, 2],
+    [1, 2, 3],
+    np.array([
+        [0.1, np.nan, 0.3],
+        [0.5, 0.2, 0.3],
+    ]),
+)
+
+mh = mm.metrics.create()
+summary = mh.compute(acc, metrics=["num_frames", "mota", "motp"], name="acc")
+print(summary)
 ```
 
-TUD-Campus
- IDF1  IDP  IDR| Rcll  Prcn   FAR| GT  MT  PT  ML|   FP    FN  IDs   FM| MOTA  MOTP MOTAL
- 55.8 73.0 45.1| 58.2  94.1  0.18|  8   1   6   1|   13   150    7    7| 52.6  72.3  54.3
+Useful lower-level pieces:
 
-TUD-Stadtmitte
- IDF1  IDP  IDR| Rcll  Prcn   FAR| GT  MT  PT  ML|   FP    FN  IDs   FM| MOTA  MOTP MOTAL
- 64.5 82.0 53.1| 60.9  94.0  0.25| 10   5   4   1|   45   452    7    6| 56.4  65.4  56.9
+- `mm.MOTAccumulator` stores frame-level matching events.
+- `mm.distances` contains distance helpers such as IoU and Euclidean matrices.
+- `mm.metrics.create()` returns a `MetricsHost` for custom metric selection.
+- `mm.utils.compare_to_groundtruth` compares loaded dataframes directly.
+- `mm.utils.compare_to_groundtruth_reweighting` supports HOTA-style multi-threshold workflows.
 
-```
+For the full HOTA/CLEAR/Identity parity check against TrackEval, see [motmetrics/tests/test_trackeval_parity.py](motmetrics/tests/test_trackeval_parity.py).
 
-In comparison to **py-motmetrics**
+## MOTChallenge Notes
 
-```
-                IDF1   IDP   IDR  Rcll  Prcn GT MT PT ML FP  FN IDs  FM  MOTA  MOTP
-TUD-Campus     55.8% 73.0% 45.1% 58.2% 94.1%  8  1  6  1 13 150   7   7 52.6% 0.277
-TUD-Stadtmitte 64.5% 82.0% 53.1% 60.9% 94.0% 10  5  4  1 45 452   7   6 56.4% 0.346
-```
+Results are aligned with the MOTChallenge devkit, with two naming/format differences:
 
-<a name="asterixcompare"></a>(\*1) Besides naming conventions, the only obvious differences are
+- `FAR` is not listed directly; it can be computed as false positives per frame.
+- MOTChallenge reports MOTP as a percentage, while py-motmetrics reports the average distance. Convert with `(1 - MOTP) * 100` for MOTChallenge-style MOTP.
 
--   Metric `FAR` is missing. This metric is given implicitly and can be recovered by `FalsePos / Frames * 100`.
--   Metric `MOTP` seems to be off. To convert compute `(1 - MOTP) * 100`. [MOTChallenge][motchallenge] benchmarks compute `MOTP` as percentage, while **py-motmetrics** sticks to the original definition of average distance over number of assigned objects [[1]](#References).
+## Development
 
-You can compare tracker results to ground truth in MOTChallenge format by
+Run the test suite:
 
-```
-python -m motmetrics.apps.eval_motchallenge --help
-```
-
-For MOT16/17, you can run
-
-```
-python -m motmetrics.apps.evaluateTracking --help
-```
-
-## Installation
-
-To install latest development version of **py-motmetrics** (usually a bit more recent than PyPi below)
-
-```
-pip install git+https://github.com/cheind/py-motmetrics.git
-```
-
-### Install via PyPi
-
-To install **py-motmetrics** use `pip`
-
-```
-pip install motmetrics
-```
-
-Python 3.8 through 3.14 and NumPy, pandas, and SciPy are required. If no binary packages are available for your platform and building source packages fails, you might want to try a distribution like Conda (see below) to install dependencies.
-
-Alternatively for developing, clone or fork this repository and install in editing mode.
-
-```
-uv venv
-uv pip install --group dev
-```
-
-To install the development dependencies and run the tests:
-
-```
-uv venv
-uv pip install --group dev
+```bash
 uv run --no-project pytest
 ```
 
-## Usage
-
-### Populating the accumulator
-
-```python
-import motmetrics as mm
-import numpy as np
-
-# Create an accumulator that will be updated during each frame
-acc = mm.MOTAccumulator(auto_id=True)
-
-# Call update once for per frame. For now, assume distances between
-# frame objects / hypotheses are given.
-acc.update(
-    [1, 2],                     # Ground truth objects in this frame
-    [1, 2, 3],                  # Detector hypotheses in this frame
-    [
-        [0.1, np.nan, 0.3],     # Distances from object 1 to hypotheses 1, 2, 3
-        [0.5,  0.2,   0.3]      # Distances from object 2 to hypotheses 1, 2, 3
-    ]
-)
-```
-
-The code above updates an event accumulator with data from a single frame. Here we assume that pairwise object / hypothesis distances have already been computed. Note `np.nan` inside the distance matrix. It signals that object `1` cannot be paired with hypothesis `2`. To inspect the current event history simple print the events associated with the accumulator.
-
-```python
-print(acc.events) # a pandas DataFrame containing all events
-
-"""
-                Type  OId HId    D
-FrameId Event
-0       0        RAW    1   1  0.1
-        1        RAW    1   2  NaN
-        2        RAW    1   3  0.3
-        3        RAW    2   1  0.5
-        4        RAW    2   2  0.2
-        5        RAW    2   3  0.3
-        6      MATCH    1   1  0.1
-        7      MATCH    2   2  0.2
-        8         FP  NaN   3  NaN
-"""
-```
-
-The above data frame contains `RAW` and MOT events. To obtain just MOT events type
-
-```python
-print(acc.mot_events) # a pandas DataFrame containing MOT only events
-
-"""
-                Type  OId HId    D
-FrameId Event
-0       6      MATCH    1   1  0.1
-        7      MATCH    2   2  0.2
-        8         FP  NaN   3  NaN
-"""
-```
-
-Meaning object `1` was matched to hypothesis `1` with distance 0.1. Similarily, object `2` was matched to hypothesis `2` with distance 0.2. Hypothesis `3` could not be matched to any remaining object and generated a false positive (FP). Possible assignments are computed by minimizing the total assignment distance (Kuhn-Munkres algorithm).
-
-Continuing from above
-
-```python
-frameid = acc.update(
-    [1, 2],
-    [1],
-    [
-        [0.2],
-        [0.4]
-    ]
-)
-print(acc.mot_events.loc[frameid])
-
-"""
-        Type OId  HId    D
-Event
-2      MATCH   1    1  0.2
-3       MISS   2  NaN  NaN
-"""
-```
-
-While object `1` was matched, object `2` couldn't be matched because no hypotheses are left to pair with.
-
-```python
-frameid = acc.update(
-    [1, 2],
-    [1, 3],
-    [
-        [0.6, 0.2],
-        [0.1, 0.6]
-    ]
-)
-print(acc.mot_events.loc[frameid])
-
-"""
-         Type OId HId    D
-Event
-4       MATCH   1   1  0.6
-5      SWITCH   2   3  0.6
-"""
-```
-
-Object `2` is now tracked by hypothesis `3` leading to a track switch. Note, although a pairing `(1, 3)` with cost less than 0.6 is possible, the algorithm prefers prefers to continue track assignments from past frames which is a property of MOT metrics.
-
-### Computing metrics
-
-Once the accumulator has been populated you can compute and display metrics. Continuing the example from above
-
-```python
-mh = mm.metrics.create()
-summary = mh.compute(acc, metrics=['num_frames', 'mota', 'motp'], name='acc')
-print(summary)
-
-"""
-     num_frames  mota  motp
-acc           3   0.5  0.34
-"""
-```
-
-Computing metrics for multiple accumulators or accumulator views is also possible
-
-```python
-summary = mh.compute_many(
-    [acc, acc.events.loc[0:1]],
-    metrics=['num_frames', 'mota', 'motp'],
-    names=['full', 'part'])
-print(summary)
-
-"""
-      num_frames  mota      motp
-full           3   0.5  0.340000
-part           2   0.5  0.166667
-"""
-```
-
-Finally, you may want to reformat column names and how column values are displayed.
-
-```python
-strsummary = mm.io.render_summary(
-    summary,
-    formatters={'mota' : '{:.2%}'.format},
-    namemap={'mota': 'MOTA', 'motp' : 'MOTP'}
-)
-print(strsummary)
-
-"""
-      num_frames   MOTA      MOTP
-full           3 50.00%  0.340000
-part           2 50.00%  0.166667
-"""
-```
-
-For MOTChallenge **py-motmetrics** provides predefined metric selectors, formatters and metric names, so that the result looks alike what is provided via their Matlab `devkit`.
-
-```python
-summary = mh.compute_many(
-    [acc, acc.events.loc[0:1]],
-    metrics=mm.metrics.motchallenge_metrics,
-    names=['full', 'part'])
-
-strsummary = mm.io.render_summary(
-    summary,
-    formatters=mh.formatters,
-    namemap=mm.io.motchallenge_metric_names
-)
-print(strsummary)
-
-"""
-      IDF1   IDP   IDR  Rcll  Prcn GT MT PT ML FP FN IDs  FM  MOTA  MOTP
-full 83.3% 83.3% 83.3% 83.3% 83.3%  2  1  1  0  1  1   1   1 50.0% 0.340
-part 75.0% 75.0% 75.0% 75.0% 75.0%  2  1  1  0  1  1   0   0 50.0% 0.167
-"""
-```
-
-In order to generate an overall summary that computes the metrics jointly over all accumulators add `generate_overall=True` as follows
-
-```python
-summary = mh.compute_many(
-    [acc, acc.events.loc[0:1]],
-    metrics=mm.metrics.motchallenge_metrics,
-    names=['full', 'part'],
-    generate_overall=True
-    )
-
-strsummary = mm.io.render_summary(
-    summary,
-    formatters=mh.formatters,
-    namemap=mm.io.motchallenge_metric_names
-)
-print(strsummary)
-
-"""
-         IDF1   IDP   IDR  Rcll  Prcn GT MT PT ML FP FN IDs  FM  MOTA  MOTP
-full    83.3% 83.3% 83.3% 83.3% 83.3%  2  1  1  0  1  1   1   1 50.0% 0.340
-part    75.0% 75.0% 75.0% 75.0% 75.0%  2  1  1  0  1  1   0   0 50.0% 0.167
-OVERALL 80.0% 80.0% 80.0% 80.0% 80.0%  4  2  2  0  2  2   1   1 50.0% 0.275
-"""
-```
-
-#### Computing HOTA metrics
-
-HOTA cannot use `MOTAccumulator` directly because it requires a reweighting matrix computed from all frames. The example below computes HOTA over the standard alpha thresholds for one or more MOTChallenge sequences:
-
-```python
-import os
-
-import numpy as np
-import pandas as pd
-
-import motmetrics as mm
-
-
-def compute_motchallenge(dir_name):
-    # `gt.txt` and `test.txt` should be prepared in MOT15 format
-    df_gt = mm.io.loadtxt(os.path.join(dir_name, "gt.txt"))
-    df_test = mm.io.loadtxt(os.path.join(dir_name, "test.txt"))
-    # Require different thresholds for matching
-    th_list = np.arange(0.05, 0.99, 0.05)
-    res_list = mm.utils.compare_to_groundtruth_reweighting(df_gt, df_test, "iou", distth=th_list)
-    return res_list
-
-
-def compute_hota(sequence_dirs):
-    sequence_accs = [compute_motchallenge(path) for path in sequence_dirs]
-    mh = mm.metrics.create()
-    metrics = ["deta_alpha", "assa_alpha", "hota_alpha"]
-    alpha_results = []
-
-    for alpha_idx in range(len(sequence_accs[0])):
-        summary = mh.compute_many(
-            [accs[alpha_idx] for accs in sequence_accs],
-            metrics=metrics,
-            names=sequence_dirs,
-            generate_overall=True,
-        )
-        alpha_results.append(summary.loc["OVERALL"])
-
-    # HOTA, DetA, and AssA are averaged over the alpha thresholds.
-    result = pd.DataFrame(alpha_results).mean().to_frame().T
-    result.index = ["OVERALL"]
-    return result, mh
-
-
-summary, mh = compute_hota([
-    "motmetrics/data/TUD-Campus",
-    "motmetrics/data/TUD-Stadtmitte",
-])
-print(mm.io.render_summary(
-    summary,
-    formatters=mh.formatters,
-    namemap={"hota_alpha": "HOTA", "assa_alpha": "AssA", "deta_alpha": "DetA"},
-))
-
-#          DetA  AssA  HOTA
-# OVERALL 39.8% 41.2% 40.0%
-```
-
-When multiple sequences are supplied, `OVERALL` follows TrackEval's combination rules: detection counts are summed for DetA, AssA is weighted by detections, and HOTA is recomputed as `sqrt(DetA * AssA)` at each alpha before the final threshold average. This avoids incorrectly averaging per-sequence HOTA values.
-
-The CI pipeline also runs py-motmetrics and TrackEval 1.3.0 over the bundled
-`TUD-Campus` and `TUD-Stadtmitte` sequences. It checks per-sequence and combined
-HOTA, CLEAR, and Identity results, including all standard HOTA alpha thresholds.
-The job prints both implementations' values and their maximum absolute difference
-to the log and GitHub job summary. It fails if any difference exceeds `1e-6`.
-To run this comparison locally:
+Run the TrackEval parity test locally:
 
 ```bash
 uv pip install trackeval==1.3.0
 uv run --no-project pytest -q motmetrics/tests/test_trackeval_parity.py
 ```
 
-### Computing distances
+## References
 
-Up until this point we assumed the pairwise object/hypothesis distances to be known. Usually this is not the case. You are mostly given either rectangles or points (centroids) of related objects. To compute a distance matrix from them you can use `motmetrics.distance` module as shown below.
-
-#### Euclidean norm squared on points
-
-```python
-# Object related points
-o = np.array([
-    [1., 2],
-    [2., 2],
-    [3., 2],
-])
-
-# Hypothesis related points
-h = np.array([
-    [0., 0],
-    [1., 1],
-])
-
-C = mm.distances.norm2squared_matrix(o, h, max_d2=5.)
-
-"""
-[[  5.   1.]
- [ nan   2.]
- [ nan   5.]]
-"""
-```
-
-#### Intersection over union norm for 2D rectangles
-
-```python
-a = np.array([
-    [0, 0, 1, 2],    # Format X, Y, Width, Height
-    [0, 0, 0.8, 1.5],
-])
-
-b = np.array([
-    [0, 0, 1, 2],
-    [0, 0, 1, 1],
-    [0.1, 0.2, 2, 2],
-])
-mm.distances.iou_matrix(a, b, max_iou=0.5)
-
-"""
-[[ 0.          0.5                nan]
- [ 0.4         0.42857143         nan]]
-"""
-```
-
-<a name="SolverBackends"></a>
-
-### Solver backends
-
-For large datasets solving the minimum cost assignment becomes the dominant runtime part. **py-motmetrics** therefore supports these solvers out of the box
-
--   `lapsolver` - https://github.com/cheind/py-lapsolver
--   `lapjv` - https://github.com/gatagat/lap
--   `scipy` - https://github.com/scipy/scipy/tree/master/scipy
--   `ortools` - https://github.com/google/or-tools
--   `munkres` - http://software.clapper.org/munkres/
-
-A comparison for different sized matrices is shown below (taken from [here](https://github.com/cheind/py-lapsolver#benchmarks))
-
-Please note that the x-axis is scaled logarithmically. Missing bars indicate excessive runtime or errors in returned result.
-![](https://github.com/cheind/py-lapsolver/raw/master/lapsolver/etc/benchmark-dtype-numpy.float32.png)
-
-By default **py-motmetrics** will try to find a LAP solver in the order of the list above. In order to temporarly replace the default solver use
-
-```python
-costs = ...
-mysolver = lambda x: ... # solver code that returns pairings
-
-with lap.set_default_solver(mysolver):
-    ...
-```
-
-## For custom dataset
-
-Use this section as a guide for calculating MOT metrics for your custom dataset.
-
-Before you begin, make sure to have Ground truth and your Tracker output data in the form of text files. The code below assumes MOT16 format for the ground truth as well as the tracker ouput. The data is arranged in the following sequence:
-
-````
-<frame number>, <object id>, <bb_left>, <bb_top>, <bb_width>, <bb_height>, <confidence>, <x>, <y>, <z>
-````
-
-A sample ground truth/tracker output file is shown below. If you are using a custom dataset, then it is highly likely that you will have to create your own ground truth file. If you already have a MOT16 format ground truth file, you can use it directly otherwise, you will need a MOT16 annotator tool to create the annotations (ground truth). You can use any tool to create your ground truth data, just make sure it is as per MOT16 format.
-
-If you can't find a tool to create your ground truth files, you can use this free MOT16 annotator [tool](https://github.com/khalidw/MOT16_Annotator) to create ground truth for your dataset which can then be used in conjunction with your tracker output to generate the MOT metrics.
-
-````
-1,1,763.00,272.00,189.00,38.00,1,-1,-1,-1
-1,2,412.00,265.00,153.00,30.00,1,-1,-1,-1
-2,1,762.00,269.00,185.00,41.00,1,-1,-1,-1
-2,2,413.00,267.00,151.00,26.00,1,-1,-1,-1
-3,1,760.00,272.00,186.00,38.00,1,-1,-1,-1
-````
-
-You can read more about MOT16 format [here](https://arxiv.org/abs/1603.00831).
-
-Following function loads the ground truth and tracker object files, processes them and produces a set of metrices.
-
-```python
-def motMetricsEnhancedCalculator(gtSource, tSource):
-  # import required packages
-  import motmetrics as mm
-  import numpy as np
-  
-  # load ground truth
-  gt = np.loadtxt(gtSource, delimiter=',')
-
-  # load tracking output
-  t = np.loadtxt(tSource, delimiter=',')
-
-  # Create an accumulator that will be updated during each frame
-  acc = mm.MOTAccumulator(auto_id=True)
-
-  # Max frame number maybe different for gt and t files
-  for frame in range(int(gt[:,0].max())):
-    frame += 1 # detection and frame numbers begin at 1
-
-    # select id, x, y, width, height for current frame
-    # required format for distance calculation is X, Y, Width, Height \
-    # We already have this format
-    gt_dets = gt[gt[:,0]==frame,1:6] # select all detections in gt
-    t_dets = t[t[:,0]==frame,1:6] # select all detections in t
-
-    C = mm.distances.iou_matrix(gt_dets[:,1:], t_dets[:,1:], \
-                                max_iou=0.5) # format: gt, t
-
-    # Call update once for per frame.
-    # format: gt object ids, t object ids, distance
-    acc.update(gt_dets[:,0].astype('int').tolist(), \
-              t_dets[:,0].astype('int').tolist(), C)
-
-  mh = mm.metrics.create()
-
-  summary = mh.compute(acc, metrics=['num_frames', 'idf1', 'idp', 'idr', \
-                                     'recall', 'precision', 'num_objects', \
-                                     'mostly_tracked', 'partially_tracked', \
-                                     'mostly_lost', 'num_false_positives', \
-                                     'num_misses', 'num_switches', \
-                                     'num_fragmentations', 'mota', 'motp' \
-                                    ], \
-                      name='acc')
-
-  strsummary = mm.io.render_summary(
-      summary,
-      #formatters={'mota' : '{:.2%}'.format},
-      namemap={'idf1': 'IDF1', 'idp': 'IDP', 'idr': 'IDR', 'recall': 'Rcll', \
-               'precision': 'Prcn', 'num_objects': 'GT', \
-               'mostly_tracked' : 'MT', 'partially_tracked': 'PT', \
-               'mostly_lost' : 'ML', 'num_false_positives': 'FP', \
-               'num_misses': 'FN', 'num_switches' : 'IDsw', \
-               'num_fragmentations' : 'FM', 'mota': 'MOTA', 'motp' : 'MOTP',  \
-              }
-  )
-  print(strsummary)
-```
-
-Run the function by pointing to the ground truth and tracker output file. A sample output is shown below.
-
-```python
-# Calculate the MOT metrics
-motMetricsEnhancedCalculator('gt/groundtruth.txt', \
-                             'to/trackeroutput.txt')
-"""
-     num_frames  IDF1       IDP       IDR      Rcll      Prcn   GT  MT  PT  ML  FP  FN  IDsw  FM      MOTA      MOTP
-acc         150  0.75  0.857143  0.666667  0.743295  0.955665  261   0   2   0   9  67     1  12  0.704981  0.244387
-"""
-```
-
-## Running tests
-
-**py-motmetrics** uses the pytest framework. To run the tests, simply `cd` into the source directly and run `pytest`.
-
-<a name="References"></a>
-
-### References
-
-1. Bernardin, Keni, and Rainer Stiefelhagen. "Evaluating multiple object tracking performance: the CLEAR MOT metrics."
-   EURASIP Journal on Image and Video Processing 2008.1 (2008): 1-10.
-2. Milan, Anton, et al. "Mot16: A benchmark for multi-object tracking." arXiv preprint arXiv:1603.00831 (2016).
-3. Li, Yuan, Chang Huang, and Ram Nevatia. "Learning to associate: Hybridboosted multi-target tracker for crowded scene."
-   Computer Vision and Pattern Recognition, 2009. CVPR 2009. IEEE Conference on. IEEE, 2009.
-4. Performance Measures and a Data Set for Multi-Target, Multi-Camera Tracking. E. Ristani, F. Solera, R. S. Zou, R. Cucchiara and C. Tomasi. ECCV 2016 Workshop on Benchmarking Multi-Target Tracking.
-
-## Docker
-
-### Update ground truth and test data:
-
-/data/train directory should contain MOT 2D 2015 Ground Truth files.
-/data/test directory should contain your results.
-
-You can check usage and directory listing at
-https://github.com/cheind/py-motmetrics/blob/master/motmetrics/apps/eval_motchallenge.py
-
-### Build Image
-
-docker build -t desired-image-name -f Dockerfile .
-
-### Run Image
-
-docker run desired-image-name
-
-(credits to [christosavg](https://github.com/christosavg))
+1. Bernardin, Keni, and Rainer Stiefelhagen. "Evaluating multiple object tracking performance: the CLEAR MOT metrics." EURASIP Journal on Image and Video Processing, 2008.
+2. Milan, Anton, et al. "MOT16: A benchmark for multi-object tracking." arXiv preprint arXiv:1603.00831, 2016.
+3. Li, Yuan, Chang Huang, and Ram Nevatia. "Learning to associate: HybridBoosted multi-target tracker for crowded scene." CVPR, 2009.
+4. Ristani, Ergys, et al. "Performance Measures and a Data Set for Multi-Target, Multi-Camera Tracking." ECCV Workshop, 2016.
 
 ## License
 
-```
-MIT License
-
-Copyright (c) 2017-2022 Christoph Heindl
-Copyright (c) 2018 Toka
-Copyright (c) 2019-2022 Jack Valmadre
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
-[pandas]: http://pandas.pydata.org/
-[motchallenge]: https://motchallenge.net/
-[devkit]: https://motchallenge.net/devkit/
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ print(summary)
 ```python
 summary.mota
 summary.idf1
+summary.hota
 summary.df.to_csv("metrics.csv")
 ```
 
@@ -69,7 +70,7 @@ mh = mm.metrics.create()
 print(mh.list_metrics_markdown())
 ```
 
-The default MOTChallenge summary includes the commonly reported CLEAR and Identity metrics. HOTA-related metrics are available through the lower-level API because they require matching over multiple alpha thresholds.
+The default MOTChallenge summary includes the commonly reported CLEAR, Identity, and HOTA metrics.
 
 ## Advanced Use
 
@@ -100,7 +101,7 @@ Useful lower-level pieces:
 - `mm.distances` contains distance helpers such as IoU and Euclidean matrices.
 - `mm.metrics.create()` returns a `MetricsHost` for custom metric selection.
 - `mm.utils.compare_to_groundtruth` compares loaded dataframes directly.
-- `mm.utils.compare_to_groundtruth_reweighting` supports HOTA-style multi-threshold workflows.
+- `mm.utils.compare_to_groundtruth_reweighting` supports custom HOTA-style multi-threshold workflows.
 
 For the full HOTA/CLEAR/Identity parity check against TrackEval, see [motmetrics/tests/test_trackeval_parity.py](motmetrics/tests/test_trackeval_parity.py).
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ summary.hota
 summary.df.to_csv("metrics.csv")
 ```
 
+By default, `evaluate_motchallenge` uses `fmt="auto"`. It detects MOTChallenge text, VATIC text, and UA-DETRAC `.mat`/`.xml` files. For ambiguous text files, pass the format explicitly:
+
+```python
+summary = mm.evaluate_motchallenge(gt, pred, fmt=mm.io.Format.MOT16)
+```
+
 Folder evaluation uses the same function:
 
 ```python

--- a/motmetrics/__init__.py
+++ b/motmetrics/__init__.py
@@ -23,6 +23,8 @@ __all__ = [
     "metrics",
     "utils",
     "evaluate_motchallenge",
+    "list_metrics",
+    "list_metrics_markdown",
     "MOTChallengeSummary",
     "MOTAccumulator",
 ]
@@ -32,3 +34,13 @@ from motmetrics.evaluation import MOTChallengeSummary, evaluate_motchallenge
 from motmetrics.mot import MOTAccumulator
 
 __version__ = _distribution_version("motmetrics")
+
+
+def list_metrics(include_deps=False):
+    """Return all registered metrics as a pandas DataFrame."""
+    return metrics.create().list_metrics(include_deps=include_deps)
+
+
+def list_metrics_markdown(include_deps=False):
+    """Return all registered metrics as a markdown table."""
+    return metrics.create().list_metrics_markdown(include_deps=include_deps)

--- a/motmetrics/__init__.py
+++ b/motmetrics/__init__.py
@@ -11,26 +11,24 @@ Christoph Heindl, 2017
 https://github.com/cheind/py-motmetrics
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 from importlib.metadata import version as _distribution_version
 
 __all__ = [
     "distances",
+    "evaluation",
     "io",
     "lap",
     "metrics",
     "utils",
+    "evaluate_motchallenge",
+    "MOTChallengeSummary",
     "MOTAccumulator",
 ]
 
-from motmetrics import distances
-from motmetrics import io
-from motmetrics import lap
-from motmetrics import metrics
-from motmetrics import utils
+from motmetrics import distances, evaluation, io, lap, metrics, utils
+from motmetrics.evaluation import MOTChallengeSummary, evaluate_motchallenge
 from motmetrics.mot import MOTAccumulator
 
 __version__ = _distribution_version("motmetrics")

--- a/motmetrics/apps/eval_motchallenge.py
+++ b/motmetrics/apps/eval_motchallenge.py
@@ -7,16 +7,10 @@
 
 """Compute metrics for trackers using MOTChallenge ground-truth data."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import argparse
-from collections import OrderedDict
-import glob
 import logging
-import os
-from pathlib import Path
 
 import motmetrics as mm
 
@@ -60,22 +54,13 @@ string.""", formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('--id_solver', type=str, help='LAP solver to use for ID metrics. Defaults to --solver.')
     parser.add_argument('--exclude_id', dest='exclude_id', default=False, action='store_true',
                         help='Disable ID metrics')
+    parser.add_argument('--n-jobs', type=int, default=1, help='Number of worker threads to use.')
     return parser.parse_args()
 
 
-def compare_dataframes(gts, ts):
+def compare_dataframes(gts, ts, n_jobs=1):
     """Builds accumulator for each sequence."""
-    accs = []
-    names = []
-    for k, tsacc in ts.items():
-        if k in gts:
-            logging.info('Comparing %s...', k)
-            accs.append(mm.utils.compare_to_groundtruth(gts[k], tsacc, 'iou', distth=0.5))
-            names.append(k)
-        else:
-            logging.warning('No ground truth for %s, skipping.', k)
-
-    return accs, names
+    return mm.evaluation.compare_dataframes(gts, ts, n_jobs=n_jobs)
 
 
 def main():
@@ -87,33 +72,18 @@ def main():
         raise ValueError('Invalid log level: {} '.format(args.loglevel))
     logging.basicConfig(level=loglevel, format='%(asctime)s %(levelname)s - %(message)s', datefmt='%I:%M:%S')
 
-    if args.solver:
-        mm.lap.default_solver = args.solver
-
-    gtfiles = glob.glob(os.path.join(args.groundtruths, '*/gt/gt.txt'))
-    tsfiles = [f for f in glob.glob(os.path.join(args.tests, '*.txt')) if not os.path.basename(f).startswith('eval')]
-
-    logging.info('Found %d groundtruths and %d test files.', len(gtfiles), len(tsfiles))
     logging.info('Available LAP solvers %s', str(mm.lap.available_solvers))
     logging.info('Default LAP solver \'%s\'', mm.lap.default_solver)
-    logging.info('Loading files.')
-
-    gt = OrderedDict([(Path(f).parts[-3], mm.io.loadtxt(f, fmt=args.fmt, min_confidence=1)) for f in gtfiles])
-    ts = OrderedDict([(os.path.splitext(Path(f).parts[-1])[0], mm.io.loadtxt(f, fmt=args.fmt)) for f in tsfiles])
-
-    mh = mm.metrics.create()
-    accs, names = compare_dataframes(gt, ts)
-
-    metrics = list(mm.metrics.motchallenge_metrics)
-    if args.exclude_id:
-        metrics = [x for x in metrics if not x.startswith('id')]
-
-    logging.info('Running metrics')
-
-    if args.id_solver:
-        mm.lap.default_solver = args.id_solver
-    summary = mh.compute_many(accs, names=names, metrics=metrics, generate_overall=True)
-    print(mm.io.render_summary(summary, formatters=mh.formatters, namemap=mm.io.motchallenge_metric_names))
+    summary = mm.evaluate_motchallenge(
+        args.groundtruths,
+        args.tests,
+        fmt=args.fmt,
+        solver=args.solver,
+        id_solver=args.id_solver,
+        exclude_id=args.exclude_id,
+        n_jobs=args.n_jobs,
+    )
+    print(summary)
     logging.info('Completed')
 
 

--- a/motmetrics/apps/list_metrics.py
+++ b/motmetrics/apps/list_metrics.py
@@ -7,12 +7,9 @@
 
 """List metrics."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 if __name__ == '__main__':
     import motmetrics
 
-    mh = motmetrics.metrics.create()
-    print(mh.list_metrics_markdown())
+    print(motmetrics.list_metrics_markdown())

--- a/motmetrics/evaluation.py
+++ b/motmetrics/evaluation.py
@@ -1,0 +1,252 @@
+# py-motmetrics - Metrics for multiple object tracker (MOT) benchmarking.
+# https://github.com/cheind/py-motmetrics/
+#
+# MIT License
+# Copyright (c) 2017-2020 Christoph Heindl, Jack Valmadre and others.
+# See LICENSE file for terms.
+
+"""High-level helpers for common tracker evaluation workflows."""
+
+from __future__ import absolute_import, division, print_function
+
+import logging
+from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from motmetrics import io, lap, utils
+from motmetrics import metrics as metrics_module
+
+
+class MOTChallengeSummary(object):
+    """MOTChallenge metric results with both dataframe and rendered views."""
+
+    def __init__(self, df, formatters=None, namemap=None):
+        self.df = df
+        self.formatters = formatters
+        self.namemap = namemap
+
+    @property
+    def dataframe(self):
+        """Alias for the raw pandas DataFrame."""
+        return self.df
+
+    @property
+    def text(self):
+        """Human-readable MOTChallenge-style table."""
+        return io.render_summary(self.df, formatters=self.formatters, namemap=self.namemap)
+
+    def render(self):
+        """Return the human-readable MOTChallenge-style table."""
+        return self.text
+
+    def __str__(self):
+        return self.text
+
+    def __repr__(self):
+        return self.text
+
+    def __len__(self):
+        return len(self.df)
+
+    def __iter__(self):
+        return iter(self.df)
+
+    def __contains__(self, key):
+        return key in self.df
+
+    def __getitem__(self, key):
+        return self.df[key]
+
+    def __getattr__(self, name):
+        return getattr(self.df, name)
+
+
+def evaluate_motchallenge(
+    groundtruths,
+    tests,
+    fmt=io.Format.MOT15_2D,
+    dist="iou",
+    distfields=None,
+    distth=0.5,
+    metrics=None,
+    name=None,
+    generate_overall=True,
+    gt_min_confidence=1,
+    solver=None,
+    id_solver=None,
+    exclude_id=False,
+    n_jobs=1,
+):
+    """Evaluate MOTChallenge files or folders and return a rich summary.
+
+    Parameters
+    ----------
+    groundtruths : str or path-like
+        Path to a ground-truth file, a sequence folder containing ``gt.txt``, or
+        a MOTChallenge root containing ``<sequence>/gt/gt.txt`` files.
+    tests : str or path-like
+        Path to a tracker result file, a sequence folder containing ``test.txt``,
+        or a MOTChallenge tracker root containing ``<sequence>.txt`` files.
+
+    Returns
+    -------
+    MOTChallengeSummary
+        Wrapper around the raw pandas DataFrame. ``print(summary)`` displays a
+        MOTChallenge-style table, while ``summary.df`` exposes the dataframe.
+    """
+    gt_path = Path(groundtruths)
+    test_path = Path(tests)
+    _validate_paths(gt_path, test_path)
+    _validate_n_jobs(n_jobs)
+
+    if solver:
+        lap.default_solver = solver
+
+    metric_names = _prepare_metrics(metrics, exclude_id)
+    metric_host = metrics_module.create()
+
+    if gt_path.is_file() and test_path.is_file():
+        gt = io.loadtxt(gt_path, fmt=fmt, min_confidence=gt_min_confidence)
+        test = io.loadtxt(test_path, fmt=fmt)
+        acc = utils.compare_to_groundtruth(gt, test, dist, distfields=distfields, distth=distth)
+
+        if id_solver:
+            lap.default_solver = id_solver
+        summary = metric_host.compute(acc, metrics=metric_names, name=name or _default_sequence_name(test_path))
+    else:
+        gt = load_motchallenge_groundtruths(gt_path, fmt=fmt, min_confidence=gt_min_confidence)
+        test = load_motchallenge_tests(test_path, fmt=fmt)
+        accs, names = compare_dataframes(gt, test, dist=dist, distfields=distfields, distth=distth, n_jobs=n_jobs)
+        if not accs:
+            raise ValueError("No matching ground-truth and tracker result files found.")
+
+        if id_solver:
+            lap.default_solver = id_solver
+        summary = metric_host.compute_many(
+            accs,
+            names=names,
+            metrics=metric_names,
+            generate_overall=generate_overall,
+            n_jobs=n_jobs,
+        )
+
+    return MOTChallengeSummary(
+        summary,
+        formatters=metric_host.formatters,
+        namemap=io.motchallenge_metric_names,
+    )
+
+
+def load_motchallenge_groundtruths(root, fmt=io.Format.MOT15_2D, min_confidence=1):
+    """Load MOTChallenge ground-truth dataframes from a file or folder."""
+    root = Path(root)
+    if root.is_file():
+        return OrderedDict([(_default_sequence_name(root), io.loadtxt(root, fmt=fmt, min_confidence=min_confidence))])
+
+    files = _find_groundtruth_files(root)
+    if not files:
+        raise ValueError("No ground-truth files found below {}.".format(root))
+    logging.info("Found %d groundtruth files.", len(files))
+    return OrderedDict((name, io.loadtxt(path, fmt=fmt, min_confidence=min_confidence)) for name, path in files.items())
+
+
+def load_motchallenge_tests(root, fmt=io.Format.MOT15_2D):
+    """Load MOTChallenge tracker result dataframes from a file or folder."""
+    root = Path(root)
+    if root.is_file():
+        return OrderedDict([(_default_sequence_name(root), io.loadtxt(root, fmt=fmt))])
+
+    files = _find_test_files(root)
+    if not files:
+        raise ValueError("No tracker result files found below {}.".format(root))
+    logging.info("Found %d test files.", len(files))
+    return OrderedDict((name, io.loadtxt(path, fmt=fmt)) for name, path in files.items())
+
+
+def compare_dataframes(gts, tests, dist="iou", distfields=None, distth=0.5, n_jobs=1):
+    """Build accumulators for matching ground-truth and tracker dataframes."""
+    _validate_n_jobs(n_jobs)
+    tasks = []
+    for name, test in tests.items():
+        if name in gts:
+            tasks.append((name, gts[name], test))
+        else:
+            logging.warning("No ground truth for %s, skipping.", name)
+
+    names = [name for name, _, _ in tasks]
+    if n_jobs == 1 or len(tasks) < 2:
+        accs = [_compare_dataframe_task(task, dist, distfields, distth) for task in tasks]
+    else:
+        with ThreadPoolExecutor(max_workers=n_jobs) as executor:
+            accs = list(executor.map(lambda task: _compare_dataframe_task(task, dist, distfields, distth), tasks))
+
+    return accs, names
+
+
+def _compare_dataframe_task(task, dist, distfields, distth):
+    name, gt, test = task
+    logging.info("Comparing %s...", name)
+    return utils.compare_to_groundtruth(gt, test, dist, distfields=distfields, distth=distth)
+
+
+def _prepare_metrics(metric_names, exclude_id):
+    if metric_names is None:
+        metric_names = list(metrics_module.motchallenge_metrics)
+    elif isinstance(metric_names, str):
+        metric_names = [metric_names]
+    else:
+        metric_names = list(metric_names)
+
+    if exclude_id:
+        metric_names = [metric_name for metric_name in metric_names if not metric_name.startswith("id")]
+    return metric_names
+
+
+def _validate_paths(gt_path, test_path):
+    if not gt_path.exists():
+        raise FileNotFoundError("Ground-truth path not found: {}".format(gt_path))
+    if not test_path.exists():
+        raise FileNotFoundError("Tracker result path not found: {}".format(test_path))
+    if gt_path.is_file() != test_path.is_file():
+        raise ValueError("Ground-truth and tracker result paths must both be files or both be folders.")
+
+
+def _validate_n_jobs(n_jobs):
+    if n_jobs < 1:
+        raise ValueError("n_jobs must be at least 1.")
+
+
+def _default_sequence_name(path):
+    path = Path(path)
+    if path.stem in ("gt", "test"):
+        return path.parent.name
+    return path.stem
+
+
+def _find_groundtruth_files(root):
+    files = OrderedDict()
+    direct = root / "gt.txt"
+    if direct.is_file():
+        files[root.name] = direct
+
+    for path in sorted(root.glob("*/gt/gt.txt")):
+        files.setdefault(path.parents[1].name, path)
+    for path in sorted(root.glob("*/gt.txt")):
+        files.setdefault(path.parent.name, path)
+    return files
+
+
+def _find_test_files(root):
+    files = OrderedDict()
+    direct = root / "test.txt"
+    if direct.is_file():
+        files[root.name] = direct
+
+    for path in sorted(root.glob("*.txt")):
+        if path.name.startswith("eval") or path.name in ("gt.txt", "test.txt"):
+            continue
+        files.setdefault(path.stem, path)
+    for path in sorted(root.glob("*/test.txt")):
+        files.setdefault(path.parent.name, path)
+    return files

--- a/motmetrics/evaluation.py
+++ b/motmetrics/evaluation.py
@@ -76,7 +76,7 @@ class MOTChallengeSummary(object):
 def evaluate_motchallenge(
     groundtruths,
     tests,
-    fmt=io.Format.MOT15_2D,
+    fmt=io.Format.AUTO,
     dist="iou",
     distfields=None,
     distth=0.5,
@@ -186,7 +186,7 @@ def evaluate_motchallenge(
     )
 
 
-def load_motchallenge_groundtruths(root, fmt=io.Format.MOT15_2D, min_confidence=1):
+def load_motchallenge_groundtruths(root, fmt=io.Format.AUTO, min_confidence=1):
     """Load MOTChallenge ground-truth dataframes from a file or folder."""
     root = Path(root)
     if root.is_file():
@@ -199,7 +199,7 @@ def load_motchallenge_groundtruths(root, fmt=io.Format.MOT15_2D, min_confidence=
     return OrderedDict((name, io.loadtxt(path, fmt=fmt, min_confidence=min_confidence)) for name, path in files.items())
 
 
-def load_motchallenge_tests(root, fmt=io.Format.MOT15_2D):
+def load_motchallenge_tests(root, fmt=io.Format.AUTO):
     """Load MOTChallenge tracker result dataframes from a file or folder."""
     root = Path(root)
     if root.is_file():

--- a/motmetrics/evaluation.py
+++ b/motmetrics/evaluation.py
@@ -14,8 +14,19 @@ from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
+
 from motmetrics import io, lap, utils
 from motmetrics import metrics as metrics_module
+
+HOTA_ALPHAS = np.arange(0.05, 0.99, 0.05)
+HOTA_ALPHA_METRICS = ["hota_alpha", "deta_alpha", "assa_alpha"]
+HOTA_SUMMARY_METRICS = OrderedDict([
+    ("hota_alpha", "hota"),
+    ("deta_alpha", "deta"),
+    ("assa_alpha", "assa"),
+])
 
 
 class MOTChallengeSummary(object):
@@ -76,6 +87,8 @@ def evaluate_motchallenge(
     solver=None,
     id_solver=None,
     exclude_id=False,
+    include_hota=True,
+    hota_alphas=None,
     n_jobs=1,
 ):
     """Evaluate MOTChallenge files or folders and return a rich summary.
@@ -88,6 +101,10 @@ def evaluate_motchallenge(
     tests : str or path-like
         Path to a tracker result file, a sequence folder containing ``test.txt``,
         or a MOTChallenge tracker root containing ``<sequence>.txt`` files.
+    include_hota : bool, optional
+        If true, append HOTA, DetA, and AssA averaged over ``hota_alphas``.
+    hota_alphas : array-like, optional
+        HOTA alpha thresholds. Defaults to the TrackEval thresholds from 0.05 to 0.95.
 
     Returns
     -------
@@ -105,15 +122,33 @@ def evaluate_motchallenge(
 
     metric_names = _prepare_metrics(metrics, exclude_id)
     metric_host = metrics_module.create()
+    if hota_alphas is None:
+        hota_alphas = HOTA_ALPHAS
+    if include_hota and dist.upper() != "IOU":
+        raise ValueError("HOTA is only supported with dist='iou'. Pass include_hota=False to skip HOTA metrics.")
 
     if gt_path.is_file() and test_path.is_file():
+        sequence_name = name or _default_sequence_name(test_path)
         gt = io.loadtxt(gt_path, fmt=fmt, min_confidence=gt_min_confidence)
         test = io.loadtxt(test_path, fmt=fmt)
         acc = utils.compare_to_groundtruth(gt, test, dist, distfields=distfields, distth=distth)
 
         if id_solver:
             lap.default_solver = id_solver
-        summary = metric_host.compute(acc, metrics=metric_names, name=name or _default_sequence_name(test_path))
+        summary = metric_host.compute(acc, metrics=metric_names, name=sequence_name)
+        if include_hota:
+            summary = _append_hota_summary(
+                summary,
+                OrderedDict([(sequence_name, gt)]),
+                OrderedDict([(sequence_name, test)]),
+                [sequence_name],
+                metric_host,
+                dist,
+                distfields,
+                hota_alphas,
+                False,
+                n_jobs,
+            )
     else:
         gt = load_motchallenge_groundtruths(gt_path, fmt=fmt, min_confidence=gt_min_confidence)
         test = load_motchallenge_tests(test_path, fmt=fmt)
@@ -130,11 +165,24 @@ def evaluate_motchallenge(
             generate_overall=generate_overall,
             n_jobs=n_jobs,
         )
+        if include_hota:
+            summary = _append_hota_summary(
+                summary,
+                gt,
+                test,
+                names,
+                metric_host,
+                dist,
+                distfields,
+                hota_alphas,
+                generate_overall,
+                n_jobs,
+            )
 
     return MOTChallengeSummary(
         summary,
-        formatters=metric_host.formatters,
-        namemap=io.motchallenge_metric_names,
+        formatters=_summary_formatters(metric_host, include_hota),
+        namemap=_summary_namemap(include_hota),
     )
 
 
@@ -184,6 +232,63 @@ def compare_dataframes(gts, tests, dist="iou", distfields=None, distth=0.5, n_jo
     return accs, names
 
 
+def _append_hota_summary(summary, gts, tests, names, metric_host, dist, distfields, hota_alphas, generate_overall, n_jobs):
+    hota_summary = _compute_hota_summary(
+        gts,
+        tests,
+        names,
+        metric_host,
+        dist,
+        distfields,
+        hota_alphas,
+        generate_overall,
+        n_jobs,
+        summary.index,
+    )
+    return pd.concat([summary, hota_summary], axis=1)
+
+
+def _compute_hota_summary(gts, tests, names, metric_host, dist, distfields, hota_alphas, generate_overall, n_jobs, index):
+    hota_accumulators = _compare_hota_dataframes(gts, tests, names, dist, distfields, hota_alphas, n_jobs)
+    per_alpha_summaries = []
+
+    for alpha_index in range(len(hota_alphas)):
+        per_alpha_summaries.append(
+            metric_host.compute_many(
+                [hota_accumulators[name][alpha_index] for name in names],
+                metrics=HOTA_ALPHA_METRICS,
+                names=names,
+                generate_overall=generate_overall,
+                n_jobs=n_jobs,
+            )
+        )
+
+    rows = []
+    for row_name in index:
+        row = OrderedDict()
+        for alpha_metric, summary_metric in HOTA_SUMMARY_METRICS.items():
+            row[summary_metric] = np.mean([summary.loc[row_name, alpha_metric] for summary in per_alpha_summaries])
+        rows.append(row)
+    return pd.DataFrame(rows, index=index)
+
+
+def _compare_hota_dataframes(gts, tests, names, dist, distfields, hota_alphas, n_jobs):
+    tasks = [(name, gts[name], tests[name]) for name in names]
+    if n_jobs == 1 or len(tasks) < 2:
+        results = [_compare_hota_dataframe_task(task, dist, distfields, hota_alphas) for task in tasks]
+    else:
+        with ThreadPoolExecutor(max_workers=n_jobs) as executor:
+            results = list(executor.map(lambda task: _compare_hota_dataframe_task(task, dist, distfields, hota_alphas), tasks))
+    return OrderedDict(results)
+
+
+def _compare_hota_dataframe_task(task, dist, distfields, hota_alphas):
+    name, gt, test = task
+    logging.info("Comparing %s for HOTA...", name)
+    accs = utils.compare_to_groundtruth_reweighting(gt, test, dist, distfields=distfields, distth=hota_alphas)
+    return name, accs
+
+
 def _compare_dataframe_task(task, dist, distfields, distth):
     name, gt, test = task
     logging.info("Comparing %s...", name)
@@ -201,6 +306,20 @@ def _prepare_metrics(metric_names, exclude_id):
     if exclude_id:
         metric_names = [metric_name for metric_name in metric_names if not metric_name.startswith("id")]
     return metric_names
+
+
+def _summary_formatters(metric_host, include_hota):
+    formatters = dict(metric_host.formatters)
+    if include_hota:
+        formatters.update({"hota": "{:.1%}".format, "deta": "{:.1%}".format, "assa": "{:.1%}".format})
+    return formatters
+
+
+def _summary_namemap(include_hota):
+    namemap = dict(io.motchallenge_metric_names)
+    if include_hota:
+        namemap.update({"hota": "HOTA", "deta": "DetA", "assa": "AssA"})
+    return namemap
 
 
 def _validate_paths(gt_path, test_path):

--- a/motmetrics/io.py
+++ b/motmetrics/io.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, division, print_function
 
 import io
 import shlex
+import xml.etree.ElementTree
 from enum import Enum
 from pathlib import Path
 
@@ -269,27 +270,27 @@ def load_detrac_xml(fname, **kwargs):
             'X', 'Y', 'Width', 'Height', 'Confidence', 'ClassId', 'Visibility'
         The dataframe is indexed by ('FrameId', 'Id')
     """
-    import xmltodict
-
-    with io.open(fname) as fd:
-        doc = xmltodict.parse(fd.read())
-    frame_list = doc['sequence']['frame']
+    root = xml.etree.ElementTree.parse(fname).getroot()
+    frame_list = root.findall('frame')
 
     parsed_gt = []
-    for f in frame_list:
-        fid = int(f['@num'])
-        target_list = f['target_list']['target']
-        if not isinstance(target_list, list):
-            target_list = [target_list]
+    for frame in frame_list:
+        fid = int(frame.attrib['num'])
+        target_list = frame.find('target_list')
+        if target_list is None:
+            continue
 
-        for t in target_list:
+        for target in target_list.findall('target'):
+            box = target.find('box')
+            if box is None:
+                continue
             row = []
             row.append(fid)
-            row.append(int(t['@id']))
-            row.append(float(t['box']['@left']))
-            row.append(float(t['box']['@top']))
-            row.append(float(t['box']['@width']))
-            row.append(float(t['box']['@height']))
+            row.append(int(target.attrib['id']))
+            row.append(float(box.attrib['left']))
+            row.append(float(box.attrib['top']))
+            row.append(float(box.attrib['width']))
+            row.append(float(box.attrib['height']))
             row.append(1)
             row.append(-1)
             row.append(-1)

--- a/motmetrics/io.py
+++ b/motmetrics/io.py
@@ -7,12 +7,12 @@
 
 """Functions for loading data and writing summaries."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-from enum import Enum
 import io
+import shlex
+from enum import Enum
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -21,6 +21,9 @@ import scipy.io
 
 class Format(Enum):
     """Enumerates supported file formats."""
+
+    AUTO = 'auto'
+    """Infer the format from the file extension and a small data sample."""
 
     MOT16 = 'mot16'
     """Milan, Anton, et al. "Mot16: A benchmark for multi-object tracking." arXiv preprint arXiv:1603.00831 (2016)."""
@@ -182,7 +185,7 @@ def load_vatictxt(fname, **kwargs):
         return df
 
 
-def load_detrac_mat(fname):
+def load_detrac_mat(fname, **kwargs):
     """Loads UA-DETRAC annotations data from mat files
 
     Competition Site: http://detrac-db.rit.albany.edu/download
@@ -207,32 +210,32 @@ def load_detrac_mat(fname):
         The dataframe is indexed by ('FrameId', 'Id')
     """
 
-    matData = scipy.io.loadmat(fname)
+    mat_data = scipy.io.loadmat(fname)
 
-    frameList = matData['gtInfo'][0][0][4][0]
-    leftArray = matData['gtInfo'][0][0][0].astype(np.float32)
-    topArray = matData['gtInfo'][0][0][1].astype(np.float32)
-    widthArray = matData['gtInfo'][0][0][3].astype(np.float32)
-    heightArray = matData['gtInfo'][0][0][2].astype(np.float32)
+    frame_list = mat_data['gtInfo'][0][0][4][0]
+    left_array = mat_data['gtInfo'][0][0][0].astype(np.float32)
+    top_array = mat_data['gtInfo'][0][0][1].astype(np.float32)
+    width_array = mat_data['gtInfo'][0][0][3].astype(np.float32)
+    height_array = mat_data['gtInfo'][0][0][2].astype(np.float32)
 
-    parsedGT = []
-    for f in frameList:
-        ids = [i + 1 for i, v in enumerate(leftArray[f - 1]) if v > 0]
+    parsed_gt = []
+    for f in frame_list:
+        ids = [i + 1 for i, v in enumerate(left_array[f - 1]) if v > 0]
         for i in ids:
             row = []
             row.append(f)
             row.append(i)
-            row.append(leftArray[f - 1, i - 1] - widthArray[f - 1, i - 1] / 2)
-            row.append(topArray[f - 1, i - 1] - heightArray[f - 1, i - 1])
-            row.append(widthArray[f - 1, i - 1])
-            row.append(heightArray[f - 1, i - 1])
+            row.append(left_array[f - 1, i - 1] - width_array[f - 1, i - 1] / 2)
+            row.append(top_array[f - 1, i - 1] - height_array[f - 1, i - 1])
+            row.append(width_array[f - 1, i - 1])
+            row.append(height_array[f - 1, i - 1])
             row.append(1)
             row.append(-1)
             row.append(-1)
             row.append(-1)
-            parsedGT.append(row)
+            parsed_gt.append(row)
 
-    df = pd.DataFrame(parsedGT,
+    df = pd.DataFrame(parsed_gt,
                       columns=['FrameId', 'Id', 'X', 'Y', 'Width', 'Height', 'Confidence', 'ClassId', 'Visibility', 'unused'])
     df.set_index(['FrameId', 'Id'], inplace=True)
 
@@ -245,7 +248,7 @@ def load_detrac_mat(fname):
     return df
 
 
-def load_detrac_xml(fname):
+def load_detrac_xml(fname, **kwargs):
     """Loads UA-DETRAC annotations data from xml files
 
     Competition Site: http://detrac-db.rit.albany.edu/download
@@ -270,16 +273,16 @@ def load_detrac_xml(fname):
 
     with io.open(fname) as fd:
         doc = xmltodict.parse(fd.read())
-    frameList = doc['sequence']['frame']
+    frame_list = doc['sequence']['frame']
 
-    parsedGT = []
-    for f in frameList:
+    parsed_gt = []
+    for f in frame_list:
         fid = int(f['@num'])
-        targetList = f['target_list']['target']
-        if not isinstance(targetList, list):
-            targetList = [targetList]
+        target_list = f['target_list']['target']
+        if not isinstance(target_list, list):
+            target_list = [target_list]
 
-        for t in targetList:
+        for t in target_list:
             row = []
             row.append(fid)
             row.append(int(t['@id']))
@@ -291,9 +294,9 @@ def load_detrac_xml(fname):
             row.append(-1)
             row.append(-1)
             row.append(-1)
-            parsedGT.append(row)
+            parsed_gt.append(row)
 
-    df = pd.DataFrame(parsedGT,
+    df = pd.DataFrame(parsed_gt,
                       columns=['FrameId', 'Id', 'X', 'Y', 'Width', 'Height', 'Confidence', 'ClassId', 'Visibility', 'unused'])
     df.set_index(['FrameId', 'Id'], inplace=True)
 
@@ -306,9 +309,37 @@ def load_detrac_xml(fname):
     return df
 
 
+def infer_format(fname):
+    """Infer a supported file format from the path and a small data sample."""
+    path = Path(fname)
+    suffix = path.suffix.lower()
+    if suffix == '.mat':
+        return Format.DETRAC_MAT
+    if suffix == '.xml':
+        return Format.DETRAC_XML
+
+    with io.open(fname, encoding='utf-8', errors='ignore') as file:
+        sample = file.read(4096)
+
+    stripped = sample.lstrip()
+    if stripped.startswith('<'):
+        return Format.DETRAC_XML
+
+    first_line = next((line.strip() for line in sample.splitlines() if line.strip()), '')
+    if not first_line:
+        raise ValueError('Cannot infer format from empty file: {}'.format(fname))
+
+    fields = _split_text_fields(first_line)
+    if _looks_like_vatic_fields(fields):
+        return Format.VATIC_TXT
+    return Format.MOT15_2D
+
+
 def loadtxt(fname, fmt=Format.MOT15_2D, **kwargs):
     """Load data from any known format."""
     fmt = Format(fmt)
+    if fmt == Format.AUTO:
+        fmt = infer_format(fname)
 
     switcher = {
         Format.MOT16: load_motchallenge,
@@ -319,6 +350,27 @@ def loadtxt(fname, fmt=Format.MOT15_2D, **kwargs):
     }
     func = switcher.get(fmt)
     return func(fname, **kwargs)
+
+
+def _split_text_fields(line):
+    try:
+        return shlex.split(line.replace(',', ' '))
+    except ValueError:
+        return line.replace(',', ' ').split()
+
+
+def _looks_like_vatic_fields(fields):
+    if len(fields) < 10:
+        return False
+    return len(fields) > 10 or not _is_number(fields[9])
+
+
+def _is_number(value):
+    try:
+        float(value)
+    except ValueError:
+        return False
+    return True
 
 
 def render_summary(summary, formatters=None, namemap=None, buf=None):

--- a/motmetrics/metrics.py
+++ b/motmetrics/metrics.py
@@ -15,6 +15,7 @@ import inspect
 import logging
 import time
 from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import pandas as pd
@@ -270,7 +271,7 @@ class MetricsHost:
         return pd.DataFrame(data, index=[name]) if return_dataframe else data
 
     def compute_many(
-        self, dfs, anas=None, metrics=None, names=None, generate_overall=False
+        self, dfs, anas=None, metrics=None, names=None, generate_overall=False, n_jobs=1
     ):
         """Compute metrics on multiple dataframe / accumulators.
 
@@ -294,6 +295,8 @@ class MetricsHost:
             using the same metrics over an accumulator that is the concatentation of
             all input containers. In creating this temporary accumulator, care is taken
             to offset frame indices avoid object id collisions.
+        n_jobs : int, optional
+            Number of worker threads to use for per-accumulator metric computation.
 
         Returns
         -------
@@ -305,23 +308,21 @@ class MetricsHost:
         elif isinstance(metrics, str):
             metrics = [metrics]
 
+        if n_jobs < 1:
+            raise ValueError("n_jobs must be at least 1.")
+
         assert names is None or len(names) == len(dfs)
         st = time.time()
         if names is None:
             names = list(range(len(dfs)))
         if anas is None:
             anas = [None] * len(dfs)
-        partials = [
-            self.compute(
-                acc,
-                ana=analysis,
-                metrics=metrics,
-                name=name,
-                return_cached=True,
-                return_dataframe=False,
-            )
-            for acc, analysis, name in zip(dfs, anas, names)
-        ]
+        jobs = list(zip(dfs, anas, names))
+        if n_jobs == 1 or len(jobs) < 2:
+            partials = [self._compute_many_one(job, metrics) for job in jobs]
+        else:
+            with ThreadPoolExecutor(max_workers=n_jobs) as executor:
+                partials = list(executor.map(lambda job: self._compute_many_one(job, metrics), jobs))
         logging.info("partials: %.3f seconds.", time.time() - st)
         details = partials
         partials = [
@@ -337,6 +338,17 @@ class MetricsHost:
             partials.append(self.compute_overall(details, metrics=metrics, name=names))
         logging.info("mergeOverall: %.3f seconds.", time.time() - st)
         return pd.concat(partials)
+
+    def _compute_many_one(self, job, metrics):
+        acc, analysis, name = job
+        return self.compute(
+            acc,
+            ana=analysis,
+            metrics=metrics,
+            name=name,
+            return_cached=True,
+            return_dataframe=False,
+        )
 
     def _compute(self, df_map, name, cache, options, parent=None):
         """Compute metric and resolve dependencies."""

--- a/motmetrics/tests/test_eval_motchallenge_app.py
+++ b/motmetrics/tests/test_eval_motchallenge_app.py
@@ -1,0 +1,67 @@
+# py-motmetrics - Metrics for multiple object tracker (MOT) benchmarking.
+# https://github.com/cheind/py-motmetrics/
+#
+# MIT License
+# Copyright (c) 2017-2020 Christoph Heindl, Jack Valmadre and others.
+# See LICENSE file for terms.
+
+"""Tests for the MOTChallenge command-line evaluator helpers."""
+
+from collections import OrderedDict
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import motmetrics as mm
+from motmetrics.apps import eval_motchallenge
+
+DATA_DIR = Path(__file__).parents[1] / "data"
+SEQUENCE_NAMES = ("TUD-Campus", "TUD-Stadtmitte")
+
+
+def load_dataframes():
+    ground_truths = OrderedDict()
+    trackers = OrderedDict()
+    for sequence_name in SEQUENCE_NAMES:
+        sequence_dir = DATA_DIR / sequence_name
+        ground_truths[sequence_name] = mm.io.loadtxt(sequence_dir / "gt.txt")
+        trackers[sequence_name] = mm.io.loadtxt(sequence_dir / "test.txt")
+    trackers["missing-ground-truth"] = trackers[SEQUENCE_NAMES[0]]
+    return ground_truths, trackers
+
+
+def summarize(accumulators, names):
+    return mm.metrics.create().compute_many(
+        accumulators,
+        metrics=mm.metrics.motchallenge_metrics,
+        names=names,
+        generate_overall=True,
+        n_jobs=1,
+    )
+
+
+def test_parallel_compare_dataframes_matches_serial():
+    ground_truths, trackers = load_dataframes()
+
+    serial_accumulators, serial_names = eval_motchallenge.compare_dataframes(
+        ground_truths,
+        trackers,
+        n_jobs=1,
+    )
+    parallel_accumulators, parallel_names = eval_motchallenge.compare_dataframes(
+        ground_truths,
+        trackers,
+        n_jobs=2,
+    )
+
+    assert serial_names == parallel_names == list(SEQUENCE_NAMES)
+    pd.testing.assert_frame_equal(
+        summarize(parallel_accumulators, parallel_names),
+        summarize(serial_accumulators, serial_names),
+    )
+
+
+def test_compare_dataframes_rejects_invalid_worker_count():
+    with pytest.raises(ValueError, match="n_jobs"):
+        eval_motchallenge.compare_dataframes(OrderedDict(), OrderedDict(), n_jobs=0)

--- a/motmetrics/tests/test_evaluation.py
+++ b/motmetrics/tests/test_evaluation.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+from shutil import copyfile
+
+import pandas as pd
+
+import motmetrics as mm
+
+DATA_DIR = Path(__file__).parents[1] / "data"
+SEQUENCE_NAMES = ("TUD-Campus", "TUD-Stadtmitte")
+
+
+def test_evaluate_motchallenge_files_returns_rich_summary():
+    summary = mm.evaluate_motchallenge(
+        DATA_DIR / "TUD-Campus" / "gt.txt",
+        DATA_DIR / "TUD-Campus" / "test.txt",
+    )
+
+    assert isinstance(summary.df, pd.DataFrame)
+    assert summary.dataframe is summary.df
+    assert list(summary.df.index) == ["TUD-Campus"]
+    assert "mota" in summary
+    assert summary["mota"].equals(summary.df["mota"])
+    assert summary.mota.equals(summary.df["mota"])
+    assert summary.loc["TUD-Campus", "mota"] == summary.df.loc["TUD-Campus", "mota"]
+    assert str(summary) == summary.text
+    assert "MOTA" in summary.text
+
+
+def test_evaluate_motchallenge_folders_returns_overall_summary(tmp_path):
+    gt_root = tmp_path / "gt"
+    test_root = tmp_path / "test"
+    test_root.mkdir()
+
+    for sequence_name in SEQUENCE_NAMES:
+        source_dir = DATA_DIR / sequence_name
+        sequence_gt_dir = gt_root / sequence_name / "gt"
+        sequence_gt_dir.mkdir(parents=True)
+        copyfile(source_dir / "gt.txt", sequence_gt_dir / "gt.txt")
+        copyfile(source_dir / "test.txt", test_root / "{}.txt".format(sequence_name))
+
+    summary = mm.evaluate_motchallenge(gt_root, test_root)
+
+    assert list(summary.df.index) == ["TUD-Campus", "TUD-Stadtmitte", "OVERALL"]
+    assert "IDF1" in summary.text
+    assert summary.to_csv().startswith(",idf1")
+
+
+def test_evaluate_motchallenge_sequence_folders():
+    summary = mm.evaluate_motchallenge(DATA_DIR / "TUD-Campus", DATA_DIR / "TUD-Campus")
+
+    assert list(summary.df.index) == ["TUD-Campus", "OVERALL"]
+
+
+def test_evaluate_motchallenge_rejects_mixed_file_and_folder_inputs():
+    gt_file = DATA_DIR / "TUD-Campus" / "gt.txt"
+
+    try:
+        mm.evaluate_motchallenge(gt_file, DATA_DIR / "TUD-Campus")
+    except ValueError as exc:
+        assert "both be files or both be folders" in str(exc)
+    else:
+        raise AssertionError("Expected mixed file/folder inputs to fail.")

--- a/motmetrics/tests/test_evaluation.py
+++ b/motmetrics/tests/test_evaluation.py
@@ -19,11 +19,14 @@ def test_evaluate_motchallenge_files_returns_rich_summary():
     assert summary.dataframe is summary.df
     assert list(summary.df.index) == ["TUD-Campus"]
     assert "mota" in summary
+    assert "hota" in summary
     assert summary["mota"].equals(summary.df["mota"])
     assert summary.mota.equals(summary.df["mota"])
+    assert summary.hota.equals(summary.df["hota"])
     assert summary.loc["TUD-Campus", "mota"] == summary.df.loc["TUD-Campus", "mota"]
     assert str(summary) == summary.text
     assert "MOTA" in summary.text
+    assert "HOTA" in summary.text
 
 
 def test_evaluate_motchallenge_folders_returns_overall_summary(tmp_path):
@@ -41,8 +44,21 @@ def test_evaluate_motchallenge_folders_returns_overall_summary(tmp_path):
     summary = mm.evaluate_motchallenge(gt_root, test_root)
 
     assert list(summary.df.index) == ["TUD-Campus", "TUD-Stadtmitte", "OVERALL"]
+    assert set(["hota", "deta", "assa"]).issubset(summary.df.columns)
     assert "IDF1" in summary.text
+    assert "HOTA" in summary.text
     assert summary.to_csv().startswith(",idf1")
+
+
+def test_evaluate_motchallenge_can_skip_hota():
+    summary = mm.evaluate_motchallenge(
+        DATA_DIR / "TUD-Campus" / "gt.txt",
+        DATA_DIR / "TUD-Campus" / "test.txt",
+        include_hota=False,
+    )
+
+    assert "hota" not in summary.df.columns
+    assert "HOTA" not in summary.text
 
 
 def test_evaluate_motchallenge_sequence_folders():

--- a/motmetrics/tests/test_io.py
+++ b/motmetrics/tests/test_io.py
@@ -7,9 +7,7 @@
 
 """Tests IO functions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 
@@ -18,6 +16,29 @@ import pandas as pd
 import motmetrics as mm
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), '../data')
+
+
+def test_infer_format():
+    """Tests format inference from extension and text contents."""
+    assert mm.io.infer_format(os.path.join(DATA_DIR, 'iotest/motchallenge.txt')) == mm.io.Format.MOT15_2D
+    assert mm.io.infer_format(os.path.join(DATA_DIR, 'iotest/vatic.txt')) == mm.io.Format.VATIC_TXT
+    assert mm.io.infer_format(os.path.join(DATA_DIR, 'iotest/detrac.mat')) == mm.io.Format.DETRAC_MAT
+    assert mm.io.infer_format(os.path.join(DATA_DIR, 'iotest/detrac.xml')) == mm.io.Format.DETRAC_XML
+
+
+def test_loadtxt_auto():
+    """Tests AUTO format dispatch matches explicit formats."""
+    cases = [
+        ('iotest/motchallenge.txt', mm.io.Format.MOT15_2D),
+        ('iotest/vatic.txt', mm.io.Format.VATIC_TXT),
+        ('iotest/detrac.mat', mm.io.Format.DETRAC_MAT),
+        ('iotest/detrac.xml', mm.io.Format.DETRAC_XML),
+    ]
+    for filename, fmt in cases:
+        path = os.path.join(DATA_DIR, filename)
+        expected = mm.io.loadtxt(path, fmt=fmt)
+        actual = mm.io.loadtxt(path, fmt='auto')
+        pd.testing.assert_frame_equal(actual, expected)
 
 
 def test_load_vatic():

--- a/motmetrics/tests/test_metrics.py
+++ b/motmetrics/tests/test_metrics.py
@@ -7,9 +7,7 @@
 
 """Tests computation of metrics from accumulator."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 
@@ -20,6 +18,24 @@ from pytest import approx
 import motmetrics as mm
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "../data")
+
+
+def test_package_level_list_metrics():
+    """Tests listing registered metrics from the package root."""
+    metric_list = mm.list_metrics()
+
+    assert isinstance(metric_list, pd.DataFrame)
+    assert list(metric_list.columns) == ["Name", "Description"]
+    assert "mota" in metric_list["Name"].values
+
+
+def test_package_level_list_metrics_markdown():
+    """Tests markdown listing from the package root."""
+    markdown = mm.list_metrics_markdown()
+
+    assert isinstance(markdown, str)
+    assert "Name|Description" in markdown
+    assert "mota" in markdown
 
 
 def test_metricscontainer_1():
@@ -540,17 +556,17 @@ def test_paper_metrics():
 
 
 def test_hota():
-    TUD_golden_ans = {  # From TrackEval
+    tud_golden_ans = {  # From TrackEval
         "TUD-Campus": {"hota": 0.3913974378451139, "deta": 0.418047030142763, "assa": 0.36912068120832836},
         "TUD-Stadtmitte": {"hota": 0.3978490169927877, "deta": 0.3922675723693166, "assa": 0.4088407518112996}
     }
-    TUD_combined_golden_ans = {  # TrackEval combine_sequences over both TUD sequences.
+    tud_combined_golden_ans = {  # TrackEval combine_sequences over both TUD sequences.
         "hota": 0.3999570912884786,
         "deta": 0.3976832912424188,
         "assa": 0.4124495298453543,
     }
 
-    DATA_DIR = "motmetrics/data"
+    data_dir = "motmetrics/data"
 
     def compute_motchallenge(dname):
         df_gt = mm.io.loadtxt(os.path.join(dname, "gt.txt"))
@@ -559,10 +575,10 @@ def test_hota():
         res_list = mm.utils.compare_to_groundtruth_reweighting(df_gt, df_test, "iou", distth=th_list)
         return res_list
 
-    accs = [compute_motchallenge(os.path.join(DATA_DIR, d)) for d in TUD_golden_ans.keys()]
+    accs = [compute_motchallenge(os.path.join(data_dir, d)) for d in tud_golden_ans.keys()]
     mh = mm.metrics.create()
 
-    for dataset_idx, dname in enumerate(TUD_golden_ans.keys()):
+    for dataset_idx, dname in enumerate(tud_golden_ans.keys()):
         deta = []
         assa = []
         hota = []
@@ -585,9 +601,9 @@ def test_hota():
         assa = sum(assa) / len(assa)
         hota = sum(hota) / len(hota)
 
-        assert deta == approx(TUD_golden_ans[dname]["deta"])
-        assert assa == approx(TUD_golden_ans[dname]["assa"])
-        assert hota == approx(TUD_golden_ans[dname]["hota"])
+        assert deta == approx(tud_golden_ans[dname]["deta"])
+        assert assa == approx(tud_golden_ans[dname]["assa"])
+        assert hota == approx(tud_golden_ans[dname]["hota"])
 
     deta = []
     assa = []
@@ -600,13 +616,13 @@ def test_hota():
                 "assa_alpha",
                 "hota_alpha",
             ],
-            names=list(TUD_golden_ans),
+            names=list(tud_golden_ans),
             generate_overall=True,
         )
         deta.append(float(summary.loc["OVERALL", "deta_alpha"]))
         assa.append(float(summary.loc["OVERALL", "assa_alpha"]))
         hota.append(float(summary.loc["OVERALL", "hota_alpha"]))
 
-    assert sum(deta) / len(deta) == approx(TUD_combined_golden_ans["deta"])
-    assert sum(assa) / len(assa) == approx(TUD_combined_golden_ans["assa"])
-    assert sum(hota) / len(hota) == approx(TUD_combined_golden_ans["hota"])
+    assert sum(deta) / len(deta) == approx(tud_combined_golden_ans["deta"])
+    assert sum(assa) / len(assa) == approx(tud_combined_golden_ans["assa"])
+    assert sum(hota) / len(hota) == approx(tud_combined_golden_ans["hota"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "numpy>=1.23.2",
     "pandas>=1.5.0",
     "scipy>=1.9.3",
-    "xmltodict>=0.13.0",
 ]
 
 [dependency-groups]
@@ -40,7 +39,6 @@ dev = [
     "numpy>=1.23.2",
     "pandas>=1.5.0",
     "scipy>=1.9.3",
-    "xmltodict>=0.13.0",
     "ruff>=0.12.0",
     "pytest>=7.4.4,<8.4.0; python_version < '3.9'",
     "pytest>=8.4.1; python_version >= '3.9'",


### PR DESCRIPTION
## Summary
- add `mm.evaluate_motchallenge` and `MOTChallengeSummary` for one-call file/folder evaluation with printable MOTChallenge tables and dataframe access
- calculate aggregated HOTA, DetA, and AssA by default in the high-level evaluator
- infer supported input formats automatically for MOTChallenge text, VATIC text, and UA-DETRAC MAT/XML files
- add package-level `mm.list_metrics()` and `mm.list_metrics_markdown()` helpers
- simplify the README around the easy metrics workflow and trim advanced boilerplate

## Why
- users currently need to know lower-level loaders, accumulators, metrics hosts, and render helpers to evaluate common MOTChallenge paths
- beginners should be able to calculate standard MOT metrics from files or folders with one obvious call
- the CLI and public Python API should share the same evaluation path to reduce drift
- supported formats can be detected well enough for the common case, while explicit `fmt=...` remains available for ambiguous files
- UA-DETRAC XML parsing does not need an extra runtime dependency, so the standard library is sufficient

## Impact
- introduces the public `mm.evaluate_motchallenge(...)` API and rich summary object with `summary.df`, `summary.text`, and direct metric access such as `summary.mota`, `summary.idf1`, and `summary.hota`
- includes HOTA, DetA, and AssA by default, with `include_hota=False` available for callers that want to skip HOTA computation
- keeps lower-level APIs available for custom accumulator, matching, and metric workflows
- refactors the MOTChallenge CLI to reuse the public evaluator and adds parallel evaluation support through `n_jobs`
- removes the `xmltodict` dependency by using `xml.etree.ElementTree` for UA-DETRAC XML files

## Tests
- `uv run --no-project pytest -q`
- `uv run --no-project ruff check motmetrics/io.py`
- focused Ruff checks on touched evaluator, metric helper, and test files